### PR TITLE
4.17.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vkui-tokens",
-  "version": "4.16.0",
+  "version": "4.17.0",
   "description": "Репозиторий, который содержит в себе дизайн-токены и другие инструменты объединенной дизайн-системы VKUI и Paradigm",
   "license": "MIT",
   "main": "utils/descriptions.js",

--- a/src/interfaces/general/colors/index.ts
+++ b/src/interfaces/general/colors/index.ts
@@ -51,6 +51,7 @@ export interface ColorsDescriptionStruct {
 	colorBackgroundPositive: ColorDescription;
 	colorBackgroundNegative: ColorDescription;
 	colorBackgroundNegativeTint: ColorDescription;
+	colorBackgroundPositiveTint: ColorDescription;
 	colorFieldBackground: ColorDescription;
 	colorHeaderBackground: ColorDescription;
 

--- a/src/interfaces/namespaces/paradigm/index.ts
+++ b/src/interfaces/namespaces/paradigm/index.ts
@@ -24,6 +24,20 @@ export interface LocalParadigmColorsDescriptionStruct {
 	colorButtonContrastAlpha: ColorDescription;
 	colorRating: ColorDescription;
 	colorThumbErrorBackgroundAlpha: ColorDescription;
+
+	colorBackgroundAccentTintThemedAlpha: ColorDescription;
+	colorBackgroundAccentTintAlpha: ColorDescription;
+	colorBackgroundAccentTintThemed: ColorDescription;
+	colorBackgroundWarningTintThemedAlpha: ColorDescription;
+	colorBackgroundWarningTintAlpha: ColorDescription;
+	colorBackgroundWarningTintThemed: ColorDescription;
+	colorBackgroundWarningTint: ColorDescription;
+	colorBackgroundNegativeTintThemedAlpha: ColorDescription;
+	colorBackgroundNegativeTintAlpha: ColorDescription;
+	colorBackgroundNegativeTintThemed: ColorDescription;
+	colorBackgroundPositiveTintThemedAlpha: ColorDescription;
+	colorBackgroundPositiveTintAlpha: ColorDescription;
+	colorBackgroundPositiveTintThemed: ColorDescription;
 }
 
 export type ParadigmLocalColors = {

--- a/src/interfaces/themes/cloudDark/index.ts
+++ b/src/interfaces/themes/cloudDark/index.ts
@@ -1,0 +1,7 @@
+import {ThemeCloud, ThemeCloudCssVars, ThemeCloudDescription} from '../cloud';
+
+export type ThemeCloudDark = ThemeCloud;
+export type ThemeCloudDarkDescription = ThemeCloudDescription;
+
+// Интерфейс ниже не используем в коде, но нужен для сборки
+export type ThemeCloudDarkCssVars = ThemeCloudCssVars;

--- a/src/interfaces/themes/octavius/index.ts
+++ b/src/interfaces/themes/octavius/index.ts
@@ -218,6 +218,15 @@ export interface LocalOctaviusColorsDescriptionStruct {
 	octaviusColorListTextPrimary: ColorDescription;
 	octaviusColorListIconPrimary: ColorDescription;
 
+	// Метатреды
+	octaviusColorIconSocial: ColorDescription;
+	octaviusColorIconMailings: ColorDescription;
+	octaviusColorIconToMyself: ColorDescription;
+	octaviusColorIconNews: ColorDescription;
+	octaviusColorIconOfficial: ColorDescription;
+	octaviusColorIconSchool: ColorDescription;
+	octaviusColorIconGames: ColorDescription;
+
 	// Другие стили
 	/**
 	 * Цвет текста подписи под картинкой пустого состояния.

--- a/src/themeDescriptions/base/paradigm.ts
+++ b/src/themeDescriptions/base/paradigm.ts
@@ -933,3 +933,11 @@ export const darkTheme: ParadigmThemeDescription = {
 		colorThumbErrorBackgroundAlpha: 'rgba(237, 10, 52, 0.12)',
 	},
 };
+
+// Для экспорта базовой темы прописываем токен themeNameBase отдельно
+// В darkThemeBase прописать не можем, т.к. он тогда перетрёт themeNameBase
+// в продуктовых темах.
+export const darkThemeExport: ParadigmThemeDescription = {
+	...darkTheme,
+	themeNameBase: 'paradigmBase',
+};

--- a/src/themeDescriptions/base/paradigm.ts
+++ b/src/themeDescriptions/base/paradigm.ts
@@ -43,6 +43,7 @@ export const lightColors: ColorsDescription = {
 		colorBackgroundModal: '#FFFFFF',
 		colorBackgroundPositive: '#0DC268',
 		colorBackgroundNegativeTint: '#FAEBEB',
+		colorBackgroundPositiveTint: '#ECFAF3',
 		colorFieldBackground: '#ffffff',
 		colorBackgroundModalInverse: '#303030',
 		colorBackgroundContrastInverse: '#303030',
@@ -152,6 +153,7 @@ export const darkColors: ColorsDescription = {
 		colorBackgroundModal: '#303030',
 		colorBackgroundPositive: '#0DC268',
 		colorBackgroundNegativeTint: '#522e2e',
+		colorBackgroundPositiveTint: '#182A22',
 		colorFieldBackground: '#232324',
 		colorBackgroundModalInverse: '#ffffff',
 		colorBackgroundContrastInverse: '#303030',
@@ -669,6 +671,24 @@ export const lightTheme: ParadigmThemeDescription = {
 			(theme) => theme.colors.colorButtonContrastAlpha,
 		),
 		colorThumbErrorBackgroundAlpha: 'rgba(237, 10, 52, 0.12)',
+
+		// Тонированные цвета для проектов
+		colorBackgroundAccentTintThemedAlpha: 'rgba(0, 95, 249, 0.06)',
+		colorBackgroundAccentTintAlpha: 'rgba(0, 95, 249, 0.06)',
+		colorBackgroundAccentTintThemed: '#f0f4ff',
+
+		colorBackgroundWarningTintThemedAlpha: 'rgba(255, 241, 173, 0.48)',
+		colorBackgroundWarningTintAlpha: 'rgba(255, 241, 173, 0.48)',
+		colorBackgroundWarningTintThemed: '#fffce0',
+		colorBackgroundWarningTint: '#fffce0',
+
+		colorBackgroundNegativeTintThemedAlpha: 'rgba(237, 10, 52, 0.08)',
+		colorBackgroundNegativeTintAlpha: 'rgba(237, 10, 52, 0.08)',
+		colorBackgroundNegativeTintThemed: '#faebeb',
+
+		colorBackgroundPositiveTintThemedAlpha: 'rgba(13, 194, 104, 0.08)',
+		colorBackgroundPositiveTintAlpha: 'rgba(13, 194, 104, 0.08)',
+		colorBackgroundPositiveTintThemed: '#ECFAF3',
 	},
 
 	breakpoints: {
@@ -931,6 +951,24 @@ export const darkTheme: ParadigmThemeDescription = {
 			active: 'rgba(255, 255, 255, 0.24)',
 		},
 		colorThumbErrorBackgroundAlpha: 'rgba(237, 10, 52, 0.12)',
+
+		// Тонированные цвета для проектов
+		colorBackgroundAccentTintThemedAlpha: 'rgba(255, 255, 255, 0.08)',
+		colorBackgroundAccentTintAlpha: 'rgba(0, 95, 249, 0.1)',
+		colorBackgroundAccentTintThemed: '#2b2b2c',
+
+		colorBackgroundWarningTintThemedAlpha: 'rgba(255, 255, 255, 0.08)',
+		colorBackgroundWarningTintAlpha: 'rgba(255, 158, 0, 0.1)',
+		colorBackgroundWarningTintThemed: '#2b2b2c',
+		colorBackgroundWarningTint: '#302617',
+
+		colorBackgroundNegativeTintThemedAlpha: 'rgba(255, 255, 255, 0.08)',
+		colorBackgroundNegativeTintAlpha: 'rgba(237, 10, 52, 0.1)',
+		colorBackgroundNegativeTintThemed: '#2b2b2c',
+
+		colorBackgroundPositiveTintThemedAlpha: 'rgba(255, 255, 255, 0.08)',
+		colorBackgroundPositiveTintAlpha: 'rgba(13, 194, 104, 0.1)',
+		colorBackgroundPositiveTintThemed: '#2b2b2c',
 	},
 };
 

--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -46,6 +46,7 @@ export const lightColors: ColorsDescription = {
 		colorBackgroundPositive: '#4BB34B',
 		colorBackgroundNegative: '#E64646',
 		colorBackgroundNegativeTint: '#FAEBEB',
+		colorBackgroundPositiveTint: '#E8f9e8',
 		colorFieldBackground: '#f2f3f5',
 		colorHeaderBackground: '#FFFFFF',
 
@@ -178,6 +179,7 @@ export const darkColors: ColorsDescription = {
 		colorBackgroundPositive: '#4BB34B',
 		colorBackgroundNegative: '#FF5C5C',
 		colorBackgroundNegativeTint: '#522E2E',
+		colorBackgroundPositiveTint: '#E8f9e8',
 		colorFieldBackground: '#292929',
 		colorHeaderBackground: '#19191A',
 

--- a/src/themeDescriptions/index.ts
+++ b/src/themeDescriptions/index.ts
@@ -29,7 +29,7 @@ import {vkComTheme, vkComThemeDark} from '@/themeDescriptions/themes/vkCom';
 import {vkIOSTheme, vkIOSThemeDark} from '@/themeDescriptions/themes/vkIOS';
 
 import {
-	darkTheme as paradigmBaseDark,
+	darkThemeExport as paradigmBaseDark,
 	lightTheme as paradigmBase,
 } from './base/paradigm';
 import {darkTheme as vkBaseDark, lightTheme as vkBase} from './base/vk';

--- a/src/themeDescriptions/index.ts
+++ b/src/themeDescriptions/index.ts
@@ -3,7 +3,7 @@ import {
 	calendarTheme,
 } from '@/themeDescriptions/themes/calendar';
 import {callsTheme} from '@/themeDescriptions/themes/calls';
-import {cloudTheme} from '@/themeDescriptions/themes/cloud';
+import {cloudDarkTheme, cloudTheme} from '@/themeDescriptions/themes/cloud';
 import {homeDarkTheme, homeTheme} from '@/themeDescriptions/themes/home';
 import {mediaDarkTheme, mediaTheme} from '@/themeDescriptions/themes/media';
 import {mycomTheme} from '@/themeDescriptions/themes/mycom';
@@ -73,10 +73,13 @@ export const themes = [
 	otvetTheme,
 	otvetDarkTheme,
 
+	// Темы, наследуемые от Cloud
+	cloudTheme,
+	cloudDarkTheme,
+
 	// Прочие темы
 	callsTheme,
 	todoTheme,
-	cloudTheme,
 	searchTheme,
 
 	// ==== Deprecated Legacy ====

--- a/src/themeDescriptions/themes/cloud/index.ts
+++ b/src/themeDescriptions/themes/cloud/index.ts
@@ -3,8 +3,9 @@ import {Property} from 'csstype';
 import {staticRef} from '@/build/helpers/tokenHelpers';
 import {Font} from '@/interfaces/general/typography';
 import {ThemeCloudDescription} from '@/interfaces/themes/cloud';
+import {ThemeCloudDarkDescription} from '@/interfaces/themes/cloudDark';
 
-import {lightTheme} from '../../base/paradigm';
+import {darkTheme, darkThemeElevation, lightTheme} from '../../base/paradigm';
 import {helpers} from '../../common';
 
 const {x2, x4, x5} = helpers;
@@ -218,5 +219,16 @@ export const cloudTheme: ThemeCloudDescription = {
 	colors: {
 		...lightTheme.colors,
 		colorBackgroundNegative: '#E64646',
+	},
+};
+
+export const cloudDarkTheme: ThemeCloudDarkDescription = {
+	...cloudTheme,
+	...darkTheme,
+	...darkThemeElevation,
+	themeName: 'cloudDark',
+	colors: {
+		...cloudTheme.colors,
+		...darkTheme.colors,
 	},
 };

--- a/src/themeDescriptions/themes/octavius/index.ts
+++ b/src/themeDescriptions/themes/octavius/index.ts
@@ -208,6 +208,14 @@ export const octaviusTheme: ThemeOctaviusDescription = {
 		octaviusColorBackgroundPositiveTintAlpha: 'rgba(13, 194, 104, 0.1)',
 
 		octaviusColorButtonBackgroundContrastAlpha: 'rgba(250, 250, 250, 0.99)',
+
+		octaviusColorIconSocial: '#7288FF',
+		octaviusColorIconMailings: '#FC8A15',
+		octaviusColorIconToMyself: '#00BD93',
+		octaviusColorIconNews: '#08ABD9',
+		octaviusColorIconOfficial: '#EC4750',
+		octaviusColorIconSchool: '#AC7EEC',
+		octaviusColorIconGames: '#F8BA04',
 	},
 
 	octaviusTextShadowEmptyStateText: 'none',


### PR DESCRIPTION
**Новые токены**
- Новые токены тонирование цветов в темах `paradigmBase`и `vk` #171
- Новые локальные токены для цветов метатредов в теме `octavius` #170

**Новые темы**
- Заведена тёмная тема для облака `cloudDark` #165 

**Изменённые токены**
- Добавлен токен `themeNameBase `в тему `paradigmBaseDark` #166 