### PR TITLE
feat(base): Add horizontal margin token for SplitCol

### DIFF
--- a/src/interfaces/general/geometry/index.ts
+++ b/src/interfaces/general/geometry/index.ts
@@ -75,6 +75,7 @@ export interface Sizes {
 	sizeFormItemPaddingVertical: number;
 
 	sizeSplitColPaddingHorizontal: number;
+	sizeSplitColMarginHorizontal: number;
 
 	sizeSubnavigationBarGap: number;
 	sizeSubnavigationBarPaddingVertical: number;

--- a/src/themeDescriptions/base/paradigm.ts
+++ b/src/themeDescriptions/base/paradigm.ts
@@ -626,6 +626,9 @@ export const lightThemeBase: ThemeDescription = {
 	sizeSplitColPaddingHorizontal: {
 		regular: 16,
 	},
+	sizeSplitColMarginHorizontal: {
+		regular: 16,
+	},
 
 	// Для регулирования расстояния между элементами в SubnavigationBar
 	sizeSubnavigationBarGap: {

--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -682,6 +682,9 @@ export const lightTheme: ThemeDescription = {
 	sizeSplitColPaddingHorizontal: {
 		regular: 16,
 	},
+	sizeSplitColMarginHorizontal: {
+		regular: 16,
+	},
 
 	// Для регулирования расстояния между элементами в SubnavigationBar
 	sizeSubnavigationBarGap: {


### PR DESCRIPTION
Перед отправкой этого реквеста на ревью убедитесь, что:
* в вашей ветке работает сборка (`npm run build:local`),
* в вашей ветке проходят тесты (`npm test`),
* в вашей ветке проходит линтер (`npm run lint`), некоторые ошибки можно автоматически поправить с помощью `npm run lint:fix`,
* покрытие тестов не ниже минимального значения,
* если вы вносите изменения в задокументированные части библиотеки,
  ваш pull request содержит обновления документации,
* если вы вносите изменения в сами токены, вы
  согласовали их с дизайнерами.

[Подробнее о внесении изменений в репозиторий токенов](https://github.com/VKCOM/vkui-tokens/blob/master/CONTRIBUTING.md)

---

Возможно, стоит избавиться в каком-нибудь мажоре от токена `sizeSplitColPaddingHorizontal` - для VKUI он ошибочный и нигде использоваться не будет
