### PR TITLE
4.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "ts-node": "10.9.1",
     "tsconfig-paths": "4.1.0",
     "tscpaths": "0.0.9",
-    "type-fest": "3.0.0",
+    "type-fest": "3.1.0",
     "typescript": "4.8.4",
     "webpack": "5.74.0",
     "webpack-cli": "4.10.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@types/jest": "26.0.23",
     "@types/node": "15.0.1",
     "@types/react": "18.0.21",
-    "@types/react-dom": "18.0.6",
+    "@types/react-dom": "18.0.8",
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.22.0",
     "@vkontakte/appearance": "https://github.com/VKCOM/Appearance#v9.51.4",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@babel/core": "7.19.3",
     "@svgr/webpack": "6.4.0",
-    "@types/color": "3.0.1",
+    "@types/color": "3.0.3",
     "@types/common-tags": "1.8.1",
     "@types/fs-extra": "9.0.13",
     "@types/jest": "26.0.23",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vkui-tokens",
-  "version": "4.21.0",
+  "version": "4.22.0",
   "description": "Репозиторий, который содержит в себе дизайн-токены и другие инструменты объединенной дизайн-системы VKUI и Paradigm",
   "license": "MIT",
   "main": "utils/descriptions.js",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/react": "18.0.21",
     "@types/react-dom": "18.0.8",
     "@typescript-eslint/eslint-plugin": "4.33.0",
-    "@typescript-eslint/parser": "4.22.0",
+    "@typescript-eslint/parser": "4.33.0",
     "@vkontakte/appearance": "https://github.com/VKCOM/Appearance#v9.51.4",
     "@vkontakte/icons": "1.201.0",
     "@vkontakte/vk-bridge": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.22.0",
     "@vkontakte/appearance": "https://github.com/VKCOM/Appearance#v9.51.4",
-    "@vkontakte/icons": "1.198.0",
+    "@vkontakte/icons": "1.201.0",
     "@vkontakte/vk-bridge": "2.7.0",
     "@vkontakte/vkui": "4.38.0",
     "babel-jest": "26.0.0",

--- a/src/interfaces/general/animations/index.ts
+++ b/src/interfaces/general/animations/index.ts
@@ -9,8 +9,28 @@ export interface Animations {
 	 * @tags animation
 	 */
 	animationEasingDefault: Property.TransitionTimingFunction;
+
+	/**
+	 * @desc Параметры кривой анимации в зависимости от платформы
+	 * @tags animation
+	 */
 	animationEasingPlatform: Property.TransitionTimingFunction;
+
+	/**
+	 * @desc Длительность анимации (минимальное значение)
+	 * @tags animation
+	 */
 	animationDurationS: string;
+
+	/**
+	 * @desc Длительность анимации (среднее значение)
+	 * @tags animation
+	 */
 	animationDurationM: string;
+
+	/**
+	 * @desc Длительность анимации (максимальное значение)
+	 * @tags animation
+	 */
 	animationDurationL: string;
 }

--- a/src/interfaces/general/colors/index.ts
+++ b/src/interfaces/general/colors/index.ts
@@ -33,62 +33,324 @@ export type ColorDescription<
  */
 export interface ColorsDescriptionStruct {
 	// Background
+	/**
+	 * @desc Акцентный фон для элементов интерфейса
+	 * @tags color, background
+	 */
 	colorBackgroundAccent: ColorDescription;
+
+	/**
+	 * @desc Акцентный фон который меняется на белый в темной теме
+	 * @tags color, background, themed
+	 */
 	colorBackgroundAccentThemed: ColorDescription;
+
+	/**
+	 * @desc Тонированный акцентный фон
+	 * @tags color, background
+	 */
 	colorBackgroundAccentTint: ColorDescription;
+
+	/**
+	 * @desc Альтернативный акцентный фон элементов интерфейса
+	 * @tags color, background
+	 */
 	colorBackgroundAccentAlternative: ColorDescription;
+
+	/**
+	 * @desc Основной фон страницы
+	 * @tags color, background
+	 */
 	colorBackground: ColorDescription;
+
+	/**
+	 * @desc Цвет фона под контентом на странице
+	 * @tags color, background
+	 */
 	colorBackgroundContent: ColorDescription;
+
+	/**
+	 * @desc Второстепенный цвет фона
+	 * @tags color, background
+	 */
 	colorBackgroundSecondary: ColorDescription;
+
+	/**
+	 * @desc Второстепенный цвет фона с прозрачностью
+	 * @tags color, background, alpha
+	 */
 	colorBackgroundSecondaryAlpha: ColorDescription;
+
+	/**
+	 * @desc Третичный цвет для фона
+	 * @tags color, background
+	 */
 	colorBackgroundTertiary: ColorDescription;
+
+	/**
+	 * @desc Третичный цвет для фона с прозрачностью
+	 * @tags color, background, alpha
+	 */
 	colorBackgroundTertiaryAlpha: ColorDescription;
+
+	/**
+	 * @desc Белый контрастный фон, не зависит от темы
+	 * @tags color, background
+	 */
 	colorBackgroundContrast: ColorDescription;
+
+	/**
+	 * @desc Второстепенный контрастный фон с прозрачностью
+	 * @tags color, background, alpha
+	 */
 	colorBackgroundContrastSecondaryAlpha: ColorDescription;
+
+	/**
+	 * @desc Противоположный белому контрастному фон, не зависит от темы
+	 * @tags color, background
+	 */
 	colorBackgroundContrastInverse: ColorDescription;
+
+	/**
+	 * @desc Фон для всплывающих окон
+	 * @tags color, background
+	 */
 	colorBackgroundModal: ColorDescription;
+
+	/**
+	 * @desc Противоположный цвет для фона всплывающих окон.
+	 * @tags color, background
+	 */
 	colorBackgroundModalInverse: ColorDescription;
+
+	/**
+	 * @desc Цвет фона предупреждающих элементов
+	 * @tags color, background
+	 */
 	colorBackgroundWarning: ColorDescription;
+
+	/**
+	 * @desc Фон для использования в позитивных сценариях работы
+	 * @tags color, background
+	 */
 	colorBackgroundPositive: ColorDescription;
+
+	/**
+	 * @desc Фон для ошибок и использования в негативных сценариях работы
+	 * @tags color, background
+	 */
 	colorBackgroundNegative: ColorDescription;
+
+	/**
+	 * @desc Тонированный фон для ошибок и использования в негативных сценариях работы
+	 * @tags color, background
+	 */
 	colorBackgroundNegativeTint: ColorDescription;
+
+	/**
+	 * @desc Тонированный фон для использования в позитивных сценариях работы
+	 * @tags color, background
+	 */
 	colorBackgroundPositiveTint: ColorDescription;
+
+	/**
+	 * @desc Фон для полей ввода, селектов и других подобных компонентов
+	 * @tags color, component, background
+	 */
 	colorFieldBackground: ColorDescription;
+
+	/**
+	 * @desc Цвет фона. Используется в компоненте Header
+	 * @tags color, component, background
+	 */
 	colorHeaderBackground: ColorDescription;
 
 	// Text
+	/**
+	 * @desc Акцентный цвет текста
+	 * @tags color, text
+	 */
 	colorTextAccent: ColorDescription;
+
+	/**
+	 * @desc Акцентный цвет текста, становится белым в темной теме
+	 * @tags color, text, themed
+	 */
 	colorTextAccentThemed: ColorDescription;
+
+	/**
+	 * @desc Основной цвет текста
+	 * @tags color, text
+	 */
 	colorTextPrimary: ColorDescription;
+
+	/**
+	 * @desc Основной цвет текста не меняется в зависимости от темы
+	 * @tags color, text
+	 */
 	colorTextPrimaryInvariably: ColorDescription;
+
+	/**
+	 * @desc Второстепенный цвет текста
+	 * @tags color, text
+	 */
 	colorTextSecondary: ColorDescription;
+
+	/**
+	 * @desc Цвет текста подзаголовков
+	 * @tags color, text
+	 */
 	colorTextSubhead: ColorDescription;
+
+	/**
+	 * @desc Третичный цвет текста
+	 * @tags color, text
+	 */
 	colorTextTertiary: ColorDescription;
+
+	/**
+	 * @desc Контрастный цвет для текста, не меняется в зависимости от темы
+	 * @tags color, text
+	 */
 	colorTextContrast: ColorDescription;
+
+	/**
+	 * @desc Контрастный цвет для текста
+	 * @tags color, text, themed
+	 */
 	colorTextContrastThemed: ColorDescription;
+
+	/**
+	 * @desc Цвет текста позитивных сценариев
+	 * @tags color, text
+	 */
 	colorTextPositive: ColorDescription;
+
+	/**
+	 * @desc Цвет текста ошибок или подсвечивания негативных сценариев
+	 * @tags color, text
+	 */
 	colorTextNegative: ColorDescription;
+
+	/**
+	 * @desc Цвет текста ссылок
+	 * @tags color, text
+	 */
 	colorTextLink: ColorDescription;
+
+	/**
+	 * @desc Цвет текста ссылок, становится белым в темной теме
+	 * @tags color, text, themed
+	 */
 	colorTextLinkThemed: ColorDescription;
+
+	/**
+	 * @desc Цвет текста посещенных ссылок
+	 * @tags color, text
+	 */
 	colorTextLinkVisited: ColorDescription;
+
+	/**
+	 * @desc Приглушенный цвет для текста
+	 * @tags color, text
+	 */
 	colorTextMuted: ColorDescription;
+
+	/**
+	 * @desc Контрастный цвет для ссылок. Белый на всех темах
+	 * @tags color
+	 */
 	colorLinkContrast: ColorDescription;
 
 	// Icons
+	/**
+	 * @desc Акцентный цвет иконок
+	 * @tags color, icon
+	 */
 	colorIconAccent: ColorDescription;
+
+	/**
+	 * @desc Акцентный цвет иконок, меняется на контрастный в темной теме
+	 * @tags color, icon, themed
+	 */
 	colorIconAccentThemed: ColorDescription;
+
+	/**
+	 * @desc Основной цвет иконок
+	 * @tags color, icon
+	 */
 	colorIconPrimary: ColorDescription;
+
+	/**
+	 * @desc Основной цвет иконок который не меняется в зависимости от тем
+	 * @tags color, icon
+	 */
 	colorIconPrimaryInvariably: ColorDescription;
+
+	/**
+	 * @desc Средний по насыщенности цвет иконок
+	 * @tags color, icon
+	 */
 	colorIconMedium: ColorDescription;
+
+	/**
+	 * @desc Средний по насыщенности цвет иконок с прозрачностью
+	 * @tags color, icon, alpha
+	 */
 	colorIconMediumAlpha: ColorDescription;
+
+	/**
+	 * @desc Второстепенный цвет для иконок
+	 * @tags color, icon
+	 */
 	colorIconSecondary: ColorDescription;
+
+	/**
+	 * @desc Второстепенный цвет для иконок с прозрачностью
+	 * @tags color, icon, alpha
+	 */
 	colorIconSecondaryAlpha: ColorDescription;
+
+	/**
+	 * @desc Третичный цвет для иконок
+	 * @tags color, icon
+	 */
 	colorIconTertiary: ColorDescription;
+
+	/**
+	 * @desc Третичный цвет для иконок с прозрачностью
+	 * @tags color, icon, alpha
+	 */
 	colorIconTertiaryAlpha: ColorDescription;
+
+	/**
+	 * @desc Белый цвет иконок
+	 * @tags color, icon
+	 */
 	colorIconContrast: ColorDescription;
+
+	/**
+	 * @desc Белый цвет иконок, который меняется в темной теме
+	 * @tags color, icon, themed
+	 */
 	colorIconContrastThemed: ColorDescription;
+
+	/**
+	 * @desc Второстепенный белый цвет иконок
+	 * @tags color, icon
+	 */
 	colorIconContrastSecondary: ColorDescription;
+
+	/**
+	 * @desc Цвет иконок для позитивных сценариев
+	 * @tags color, icon
+	 */
 	colorIconPositive: ColorDescription;
+
+	/**
+	 * @desc Цвет иконок для ошибок и других негативных сценариев
+	 * @tags color, icon
+	 */
 	colorIconNegative: ColorDescription;
 
 	// Stroke
@@ -97,45 +359,223 @@ export interface ColorsDescriptionStruct {
 	 * @tags color,stroke
 	 */
 	colorStrokeAccent: ColorDescription;
+
+	/**
+	 * @desc Цвет акцентной ободки, на темной теме становится белым
+	 * @tags color, stroke, themed
+	 */
 	colorStrokeAccentThemed: ColorDescription;
+
+	/**
+	 * @desc Цвет обводки позитивных сценариев
+	 * @tags color, stroke
+	 */
 	colorStrokePositive: ColorDescription;
+
+	/**
+	 * @desc Цвет для обводки ошибок или подсвечивания негативных сценариев
+	 * @tags color, stroke
+	 */
 	colorStrokeNegative: ColorDescription;
+
+	/**
+	 * @desc Контрастный цвет для обводки. Не меняется в зивисимости от темы
+	 * @tags color, stroke
+	 */
 	colorStrokeContrast: ColorDescription;
+
+	/**
+	 * @desc Цвет обводки для изображений с прозрачностью
+	 * @tags color, component, alpha
+	 */
 	colorImageBorderAlpha: ColorDescription;
+
+	/**
+	 * @desc Обводка полей ввода, селектов и других компонентов. С прозрачностью
+	 * @tags color, component, alpha
+	 */
 	colorFieldBorderAlpha: ColorDescription;
+
+	/**
+	 * @desc Цвет разделителей основной с прозрачностью
+	 * @tags color, stroke, alpha
+	 */
 	colorSeparatorPrimaryAlpha: ColorDescription;
+
+	/**
+	 * @desc Цвет разделителей второстепенный
+	 * @tags color, stroke
+	 */
 	colorSeparatorSecondary: ColorDescription;
+
+	/**
+	 * @desc Цвет разделителей основной
+	 * @tags color, stroke
+	 */
 	colorSeparatorPrimary: ColorDescription;
+
+	/**
+	 * @desc Цвет разделителей основной для экранов с разрешением 2х
+	 * @tags color, stroke
+	 */
 	colorSeparatorPrimary2x: ColorDescription;
+
+	/**
+	 * @desc Цвет разделителей основной для экранов с разрешением 3х
+	 * @tags color, stroke
+	 */
 	colorSeparatorPrimary3x: ColorDescription;
 
 	// Palette
+	/**
+	 * @desc Палитра цветов. Голубой цвет
+	 * @tags color, palette
+	 */
 	colorAccentBlue: ColorDescription;
+
+	/**
+	 * @desc Палитра цветов. Серый цвет
+	 * @tags color, palette
+	 */
 	colorAccentGray: ColorDescription;
+
+	/**
+	 * @desc Палитра цветов. Красный цвет
+	 * @tags color, palette
+	 */
 	colorAccentRed: ColorDescription;
+
+	/**
+	 * @desc Палитра цветов. Зелёный цвет
+	 * @tags color, palette
+	 */
 	colorAccentGreen: ColorDescription;
+
+	/**
+	 * @desc Палитра цветов. Оранжевый цвет
+	 * @tags color, palette
+	 */
 	colorAccentOrange: ColorDescription;
+
+	/**
+	 * @desc Палитра цветов. Фиолетовый цвет
+	 * @tags color, palette
+	 */
 	colorAccentPurple: ColorDescription;
+
+	/**
+	 * @desc Палитра цветов. Лиловый цвет
+	 * @tags color, palette
+	 */
 	colorAccentViolet: ColorDescription;
+
+	/**
+	 * @desc Второстепенный акцентный цвет для отдельных проектов
+	 * @tags color, palette
+	 */
 	colorAccentSecondary: ColorDescription;
 
 	// Other
+	/**
+	 * @desc Основной цвет для подложек оверлеев
+	 * @tags color, overlay
+	 */
 	colorOverlayPrimary: ColorDescription;
+
+	/**
+	 * @desc Фон для компонента Avatar. Не прозрачный
+	 * @tags color, component
+	 */
 	colorAvatarOverlay: ColorDescription;
+
+	/**
+	 * @desc Фон для компонента Avatar противоположный токену colorAvatarOverlay. Прозрачный
+	 * @tags color, component, alpha
+	 */
 	colorAvatarOverlayInverseAlpha: ColorDescription;
+
+	/**
+	 * @desc Цвет изображения для плейсхолдера
+	 * @tags color, component
+	 */
 	colorImagePlaceholder: ColorDescription;
+
+	/**
+	 * @desc Цвет изображения для плейсхолдера с прозрачностью
+	 * @tags color, component, alpha
+	 */
 	colorImagePlaceholderAlpha: ColorDescription;
+
+	/**
+	 * @desc Цвет для компонента Skeleton. Начальная точка градиента
+	 * @tags color, component
+	 */
 	colorSkeletonFrom: ColorDescription;
+
+	/**
+	 * @desc Цвет для компонента Skeleton. Конечная точка градиента
+	 * @tags color, component
+	 */
 	colorSkeletonTo: ColorDescription;
+
+	/**
+	 * @desc Цвет иконок в компоненте WriteBar
+	 * @tags color, component, icon
+	 */
 	colorWriteBarIcon: ColorDescription;
+
+	/**
+	 * @desc Цвет фона поля ввода в компоненте WriteBar
+	 * @tags color, component, background
+	 */
 	colorWriteBarInputBackground: ColorDescription;
+
+	/**
+	 * @desc Цвет фона поля ввода в компоненте WriteBar с прозрачностью
+	 * @tags color, component, alpha
+	 */
 	colorWriteBarInputBorderAlpha: ColorDescription;
+
+	/**
+	 * @desc Цветовой токен для компонента ActionSheet. Отвечает за цвет текста
+	 * @tags color, component, text
+	 */
 	colorActionSheetText: ColorDescription;
+
+	/**
+	 * @desc Цвет фона для компонента Progress
+	 * @tags color, component, background
+	 */
 	colorTrackBackground: ColorDescription;
+
+	/**
+	 * @desc Цвет фона заполнения для компонента Progress
+	 * @tags color, component
+	 */
 	colorTrackBuffer: ColorDescription;
+
+	/**
+	 * @desc Цвет фона поиска. Компонент Search
+	 * @tags color, component, background
+	 */
 	colorSearchFieldBackground: ColorDescription;
+
+	/**
+	 * @desc Цвет иконок в компоненте PanelHeader
+	 * @tags color, component, icon
+	 */
 	colorPanelHeaderIcon: ColorDescription;
+
+	/**
+	 * @desc Прозрачный цвет. Используется для создания эффектов состояний для прозрачных компонентов
+	 * @tags color, alpha, service
+	 */
 	colorTransparent: ColorDescription;
+
+	/**
+	 * @desc Фон элементов компонента SegmentedControl
+	 * @tags color, component, background
+	 */
 	colorSegmentedControl: ColorDescription;
 
 	// Themed цвета, в тёмной теме становится белыми

--- a/src/interfaces/general/typography/index.ts
+++ b/src/interfaces/general/typography/index.ts
@@ -18,28 +18,108 @@ export type Font = {
  * Переменные, отвечающие за группы переменных, отвечающих за шрифты
  */
 export interface Fonts {
+	/**
+	 * @desc Основной заголовок, уровень 1
+	 * @tags font
+	 */
 	fontTitle1: Font;
+
+	/**
+	 * @desc Основной заголовок, уровень 2
+	 * @tags font
+	 */
 	fontTitle2: Font;
+
+	/**
+	 * @desc Основной заголовок, уровень 3
+	 * @tags font
+	 */
 	fontTitle3: Font;
+
 	/**
 	 * @desc Legacy. Сейчас не используется в компонентах
-	 * @tags font
+	 * @tags font, legacy
 	 * @deprecated
 	 * @see fontHeadline1
 	 */
 	fontHeadline: Font;
+
+	/**
+	 * @desc Акцентный текст. Используется в больших кнопках
+	 * @tags font
+	 */
 	fontHeadline1: Font;
+
+	/**
+	 * @desc Акцентный текст. Используется в средних кнопках
+	 * @tags font
+	 */
 	fontHeadline2: Font;
+
+	/**
+	 * @desc Основной текст. Имеет разное значение в зависимости от платформы
+	 * @tags font
+	 */
 	fontText: Font;
+
+	/**
+	 * @desc Основной текст. Не меняется в зависимости от платформы
+	 * @tags font
+	 */
 	fontParagraph: Font;
+
+	/**
+	 * @desc Текст подзаголовка. Акцентный. Используется также в маленьких кнопках
+	 * @tags font
+	 */
 	fontSubhead: Font;
+
+	/**
+	 * @desc Текст подписей
+	 * @tags font
+	 */
 	fontFootnote: Font;
+
+	/**
+	 * @desc Текст подписей строчными буквами
+	 * @tags font
+	 */
 	fontFootnoteCaps: Font;
+
+	/**
+	 * @desc Текст для подсказок, уровень 1
+	 * @tags font
+	 */
 	fontCaption1: Font;
+
+	/**
+	 * @desc Текст для подсказок строчными буквами, уровень 1
+	 * @tags font
+	 */
 	fontCaption1Caps: Font;
+
+	/**
+	 * @desc Текст для подсказок, уровень 2
+	 * @tags font
+	 */
 	fontCaption2: Font;
+
+	/**
+	 * @desc Текст для подсказок строчными буквами, уровень 2
+	 * @tags font
+	 */
 	fontCaption2Caps: Font;
+
+	/**
+	 * @desc Текст для подсказок, уровень 3
+	 * @tags font
+	 */
 	fontCaption3: Font;
+
+	/**
+	 * @desc Текст для подсказок строчными буквами, уровень 3
+	 * @tags font
+	 */
 	fontCaption3Caps: Font;
 }
 
@@ -52,11 +132,46 @@ export interface TypographyBaseProps {
 	 * @tags font
 	 */
 	fontFamilyAccent: Property.FontFamily;
+
+	/**
+	 * @desc Семейство шрифтов для основного текста
+	 * @tags font
+	 */
 	fontFamilyBase: Property.FontFamily;
+
+	/**
+	 * @desc Размер веса шрифта акцентного семейства. Самый большой
+	 * @tags font
+	 */
 	fontWeightAccent1: Property.FontWeight;
+
+	/**
+	 * @desc Размер веса шрифта акцентного семейства. Средний
+	 * @tags font
+	 */
 	fontWeightAccent2: Property.FontWeight;
+
+	/**
+	 * @desc Размер веса шрифта акцентного семейства. Маленький
+	 * @tags font
+	 */
 	fontWeightAccent3: Property.FontWeight;
+
+	/**
+	 * @desc Размер веса шрифта базового семейства. Самый большой
+	 * @tags font
+	 */
 	fontWeightBase1: Property.FontWeight;
+
+	/**
+	 * @desc Размер веса шрифта базового семейства. Средний
+	 * @tags font
+	 */
 	fontWeightBase2: Property.FontWeight;
+
+	/**
+	 * @desc Размер веса шрифта базового семейства. Маленький
+	 * @tags font
+	 */
 	fontWeightBase3: Property.FontWeight;
 }

--- a/src/interfaces/namespaces/paradigm/index.ts
+++ b/src/interfaces/namespaces/paradigm/index.ts
@@ -20,31 +20,111 @@ import {
 import {Font} from '@/interfaces/general/typography';
 
 export interface LocalParadigmColorsDescriptionStruct {
+	/**
+	 * @desc Legacy. Цвет для контрастных кнопок Paradigm
+	 * @tags color, component, legacy
+	 */
 	colorButtonContrast: ColorDescription;
+
+	/**
+	 * @desc Legacy. Цвет для контрастных кнопок Paradigm с прозрачностью
+	 * @tags color, component, legacy, alpha
+	 */
 	colorButtonContrastAlpha: ColorDescription;
+
+	/**
+	 * @desc Legacy. Цвет для рейтингов
+	 * @tags color, component, legacy
+	 */
 	colorRating: ColorDescription;
+
+	/**
+	 * @desc Legacy. Цвет фона компонента Thumb с ошибкой
+	 * @tags color, component, background, legacy, alpha
+	 */
 	colorThumbErrorBackgroundAlpha: ColorDescription;
 
 	/**
 	 * @desc Тонированный акцентный фон с прозрачностью меняется на белый в темной теме
-	 * @tags color,background,alpha,themed
+	 * @tags color, background, alpha, themed
 	 */
 	colorBackgroundAccentTintThemedAlpha: ColorDescription;
+
 	/**
 	 * @desc Тонированный акцентный фон с прозрачностью
-	 * @tags color,background,alpha
+	 * @tags color, background, alpha
 	 */
 	colorBackgroundAccentTintAlpha: ColorDescription;
+
+	/**
+	 * @desc Тонированный акцентный фон меняется на белый в темной теме
+	 * @tags color, background, themed
+	 */
 	colorBackgroundAccentTintThemed: ColorDescription;
+
+	/**
+	 * @desc Тонированный цвет фона предупреждающих элементов. Меняется на
+	 *       нейтральный в темной теме. С прозрачностью
+	 * @tags color, background, alpha, themed
+	 */
 	colorBackgroundWarningTintThemedAlpha: ColorDescription;
+
+	/**
+	 * @desc Тонированный цвет фона предупреждающих элементов с прозрачностью
+	 * @tags color, background, alpha
+	 */
 	colorBackgroundWarningTintAlpha: ColorDescription;
+
+	/**
+	 * @desc Тонированный цвет фона предупреждающих элементов. Меняется на нейтральный в темной теме
+	 * @tags color, background, themed
+	 */
 	colorBackgroundWarningTintThemed: ColorDescription;
+
+	/**
+	 * @desc Тонированный цвет фона предупреждающих элементов
+	 * @tags color, background
+	 */
 	colorBackgroundWarningTint: ColorDescription;
+
+	/**
+	 * @desc Тонированный фон для ошибок и использования в негативных сценариях
+	 *       работы. Меняется на нейтральный в темной теме. С прозрачностью
+	 * @tags color, background, alpha, themed
+	 */
 	colorBackgroundNegativeTintThemedAlpha: ColorDescription;
+
+	/**
+	 * @desc Тонированный фон для ошибок и использования в негативных сценариях работы с прозрачностью
+	 * @tags color, background, alpha
+	 */
 	colorBackgroundNegativeTintAlpha: ColorDescription;
+
+	/**
+	 * @desc Тонированный фон для ошибок и использования в негативных сценариях
+	 *       работы. Меняется на нейтральный в темной теме
+	 * @tags color, background, themed
+	 */
 	colorBackgroundNegativeTintThemed: ColorDescription;
+
+	/**
+	 * @desc Тонированный фон для использования в позитивных сценариях работы.
+	 *       Меняется на нейтральный в темной теме. С прозрачностью
+	 * @tags color, background, alpha, themed
+	 */
 	colorBackgroundPositiveTintThemedAlpha: ColorDescription;
+
+	/**
+	 * @desc Тонированный фон для использования в позитивных сценариях работы с прозрачностью
+	 * @tags color, background, alpha
+	 */
 	colorBackgroundPositiveTintAlpha: ColorDescription;
+
+	/**
+	 * @desc Тонированный фон для использования в позитивных сценариях работы.
+	 *       Меняется на нейтральный в темной теме
+	 * @tags color, background, themed
+	 */
 	colorBackgroundPositiveTintThemed: ColorDescription;
 }
 
@@ -143,11 +223,23 @@ export interface ParadigmLocalFonts {
 	// большие шрифты
 	/**
 	 * @desc Legacy. Крупный заголовок из темы Paradigm
-	 * @tags font
+	 * @tags font, legacy
 	 * @deprecated
 	 */
 	fontH0: Font;
+
+	/**
+	 * @desc Legacy. Крупный заголовок из темы Paradigm
+	 * @tags font, legacy
+	 * @deprecated
+	 */
 	fontH1: Font;
+
+	/**
+	 * @desc Legacy. Крупный заголовок из темы Paradigm
+	 * @tags font, legacy
+	 * @deprecated
+	 */
 	fontH2: Font;
 }
 

--- a/src/themeDescriptions/base/paradigm.ts
+++ b/src/themeDescriptions/base/paradigm.ts
@@ -149,9 +149,9 @@ export const darkColors: ColorsDescription = {
 		colorBackgroundContent: '#232324',
 		colorBackgroundSecondary: '#2A2A2B',
 		colorBackgroundSecondaryAlpha: {
-			normal: 'rgba(255, 255, 255, 0.03)',
-			hover: 'rgba(255, 255, 255, 0.11)',
-			active: 'rgba(255, 255, 255, 0.15)',
+			normal: 'rgba(255, 255, 255, 0.08)',
+			hover: 'rgba(255, 255, 255, 0.16)',
+			active: 'rgba(255, 255, 255, 0.2)',
 		},
 		colorBackgroundTertiary: colorBackgroundTertiaryDark,
 		colorBackgroundTertiaryAlpha: {

--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -6,10 +6,10 @@ import {ColorsDescription, ThemeDescription} from '@/interfaces/general';
 import {Elevation} from '@/interfaces/general/elevation';
 import {Gradients} from '@/interfaces/general/gradients';
 
-const fontFamilyAccent =
-	'-apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif';
-const fontFamilyBase =
-	'-apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif';
+const FONT_FAMILY_DEFAULT = 'VK Sans Text';
+
+const fontFamilyAccent = `"${FONT_FAMILY_DEFAULT}", -apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif`;
+const fontFamilyBase = `"${FONT_FAMILY_DEFAULT}", -apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif`;
 const fontWeightAccent1 = 600;
 const fontWeightAccent2 = 500;
 const fontWeightAccent3 = 400;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8677,10 +8677,10 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.0.0.tgz#678e2e8d916e3b7dc1c3a6591d399ba3f7521584"
-  integrity sha512-MINvUN5ug9u+0hJDzSZNSnuKXI8M4F5Yvb6SQZ2CYqe7SgKXKOosEcU5R7tRgo85I6eAVBbkVF7TCvB4AUK2xQ==
+type-fest@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-3.1.0.tgz#157b74044d9c27fd796b9c6aa46eae6658b1e9b8"
+  integrity sha512-StmrZmK3eD9mDF9Vt7UhqthrDSk66O9iYl5t5a0TSoVkHjl0XZx/xuc/BRz4urAXXGHOY5OLsE0RdJFIApSFmw==
 
 type-fest@^0.20.2:
   version "0.20.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2180,23 +2180,15 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/parser@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.22.0.tgz#e1637327fcf796c641fe55f73530e90b16ac8fe8"
-  integrity sha512-z/bGdBJJZJN76nvAY9DkJANYgK3nlRstRRi74WHm3jjgf2I8AglrSY+6l7ogxOmn55YJ6oKZCLLy+6PW70z15Q==
+"@typescript-eslint/parser@4.33.0":
+  version "4.33.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.33.0.tgz#dfe797570d9694e560528d18eecad86c8c744899"
+  integrity sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==
   dependencies:
-    "@typescript-eslint/scope-manager" "4.22.0"
-    "@typescript-eslint/types" "4.22.0"
-    "@typescript-eslint/typescript-estree" "4.22.0"
-    debug "^4.1.1"
-
-"@typescript-eslint/scope-manager@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.22.0.tgz#ed411545e61161a8d702e703a4b7d96ec065b09a"
-  integrity sha512-OcCO7LTdk6ukawUM40wo61WdeoA7NM/zaoq1/2cs13M7GyiF+T4rxuA4xM+6LeHWjWbss7hkGXjFDRcKD4O04Q==
-  dependencies:
-    "@typescript-eslint/types" "4.22.0"
-    "@typescript-eslint/visitor-keys" "4.22.0"
+    "@typescript-eslint/scope-manager" "4.33.0"
+    "@typescript-eslint/types" "4.33.0"
+    "@typescript-eslint/typescript-estree" "4.33.0"
+    debug "^4.3.1"
 
 "@typescript-eslint/scope-manager@4.33.0":
   version "4.33.0"
@@ -2206,28 +2198,10 @@
     "@typescript-eslint/types" "4.33.0"
     "@typescript-eslint/visitor-keys" "4.33.0"
 
-"@typescript-eslint/types@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.22.0.tgz#0ca6fde5b68daf6dba133f30959cc0688c8dd0b6"
-  integrity sha512-sW/BiXmmyMqDPO2kpOhSy2Py5w6KvRRsKZnV0c4+0nr4GIcedJwXAq+RHNK4lLVEZAJYFltnnk1tJSlbeS9lYA==
-
 "@typescript-eslint/types@4.33.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
   integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
-
-"@typescript-eslint/typescript-estree@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.22.0.tgz#b5d95d6d366ff3b72f5168c75775a3e46250d05c"
-  integrity sha512-TkIFeu5JEeSs5ze/4NID+PIcVjgoU3cUQUIZnH3Sb1cEn1lBo7StSV5bwPuJQuoxKXlzAObjYTilOEKRuhR5yg==
-  dependencies:
-    "@typescript-eslint/types" "4.22.0"
-    "@typescript-eslint/visitor-keys" "4.22.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-glob "^4.0.1"
-    semver "^7.3.2"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@4.33.0":
   version "4.33.0"
@@ -2241,14 +2215,6 @@
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/visitor-keys@4.22.0":
-  version "4.22.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.22.0.tgz#169dae26d3c122935da7528c839f42a8a42f6e47"
-  integrity sha512-nnMu4F+s4o0sll6cBSsTeVsT4cwxB7zECK3dFxzEjPBii9xLpq4yqqsy/FU5zMfan6G60DKZSCXAa3sHJZrcYw==
-  dependencies:
-    "@typescript-eslint/types" "4.22.0"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.33.0":
   version "4.33.0"
@@ -4566,17 +4532,6 @@ fast-glob@^2.2.6:
     merge2 "^1.2.3"
     micromatch "^3.1.10"
 
-fast-glob@^3.1.1:
-  version "3.2.7"
-  resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.7.tgz#fd6cb7a2d7e9aa7a7846111e85a196d6b2f766a1"
-  integrity sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==
-  dependencies:
-    "@nodelib/fs.stat" "^2.0.2"
-    "@nodelib/fs.walk" "^1.2.3"
-    glob-parent "^5.1.2"
-    merge2 "^1.3.0"
-    micromatch "^4.0.4"
-
 fast-glob@^3.2.11, fast-glob@^3.2.9:
   version "3.2.12"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.2.12.tgz#7f39ec99c2e6ab030337142da9e0c18f37afae80"
@@ -4924,18 +4879,6 @@ globals@^13.6.0, globals@^13.9.0:
   dependencies:
     type-fest "^0.20.2"
 
-globby@^11.0.1:
-  version "11.0.4"
-  resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.4.tgz#2cbaff77c2f2a62e71e9b2813a67b97a3a3001a5"
-  integrity sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==
-  dependencies:
-    array-union "^2.1.0"
-    dir-glob "^3.0.1"
-    fast-glob "^3.1.1"
-    ignore "^5.1.4"
-    merge2 "^1.3.0"
-    slash "^3.0.0"
-
 globby@^11.0.3:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
@@ -5271,7 +5214,7 @@ ignore@^4.0.3, ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
-ignore@^5.1.1, ignore@^5.1.4, ignore@^5.1.8, ignore@^5.2.0:
+ignore@^5.1.1, ignore@^5.1.8, ignore@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.2.0.tgz#6d3bac8fa7fe0d45d9f9be7bac2fc279577e345a"
   integrity sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==
@@ -8651,7 +8594,7 @@ tslib@^2.0.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
-tsutils@^3.17.1, tsutils@^3.21.0:
+tsutils@^3.21.0:
   version "3.21.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-3.21.0.tgz#b48717d394cea6c1e096983eed58e9d61715b623"
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2262,10 +2262,10 @@
   version "1.0.0"
   resolved "https://github.com/VKCOM/Appearance#b38b6c9448c79d39f2618cfb821e7199e82e8f38"
 
-"@vkontakte/icons@1.198.0":
-  version "1.198.0"
-  resolved "https://registry.yarnpkg.com/@vkontakte/icons/-/icons-1.198.0.tgz#678566ed2555332d1768f665bf08d0b95ac9ffe9"
-  integrity sha512-diOdYknLIOk+q7djwQtoVDBzqxwW3s6KPSosY4hjzXVGPYlujKT+MhE51bs3e1M/YiP5QTvRC20bXroKOMyKrQ==
+"@vkontakte/icons@1.201.0":
+  version "1.201.0"
+  resolved "https://registry.yarnpkg.com/@vkontakte/icons/-/icons-1.201.0.tgz#6fbebb00f762ed8db8e4bee507859317c4931642"
+  integrity sha512-6aF7CxB3iWTEebkwGtZMBrUvMl90xOd8jApOWqsM0j060cKSwy55zvguXjBDWwq4Yqply5OxsMtd/8aiAemHdQ==
   dependencies:
     svg-baker-runtime "1.4.7"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2082,10 +2082,10 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
-"@types/react-dom@18.0.6":
-  version "18.0.6"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.6.tgz#36652900024842b74607a17786b6662dd1e103a1"
-  integrity sha512-/5OFZgfIPSwy+YuIBP/FgJnQnsxhZhjjrnxudMddeblOouIodEQ75X14Rr4wGSG/bknL+Omy9iWlLo1u/9GzAA==
+"@types/react-dom@18.0.8":
+  version "18.0.8"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.0.8.tgz#d2606d855186cd42cc1b11e63a71c39525441685"
+  integrity sha512-C3GYO0HLaOkk9dDAz3Dl4sbe4AKUGTCfFIZsz3n/82dPNN8Du533HzKatDxeUYWu24wJgMP1xICqkWk1YOLOIw==
   dependencies:
     "@types/react" "*"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1894,10 +1894,10 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
-"@types/color@3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@types/color/-/color-3.0.1.tgz#2900490ed04da8116c5058cd5dba3572d5a25071"
-  integrity sha512-oeUWVaAwI+xINDUx+3F2vJkl/vVB03VChFF/Gl3iQCdbcakjuoJyMOba+3BXRtnBhxZ7uBYqQBi9EpLnvSoztA==
+"@types/color@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@types/color/-/color-3.0.3.tgz#e6d8d72b7aaef4bb9fe80847c26c7c786191016d"
+  integrity sha512-X//qzJ3d3Zj82J9sC/C18ZY5f43utPbAJ6PhYt/M7uG6etcF6MRpKdN880KBy43B0BMzSfeT96MzrsNjFI3GbA==
   dependencies:
     "@types/color-convert" "*"
 


### PR DESCRIPTION
**Изменённые токены**
- Исправлен токен `colorBackgroundSecondaryAlpha` в базовой теме `paradigm` #269
- Шрифт VK Sans Text установлен по умолчанию для всех токенов базовой темы `vk` #273

**Инфраструктура**
- Добавлена документация в JSDoc к токеном цветов и шрифтов #271
- Изменены версии devDeps:
  - @types/color с 3.0.1 на 3.0.3 #262 
  - @typescript-eslint/parser с 4.22.0 на 4.33.0  #263 
  - @vkontakte/icons с 1.198.0 на 1.201.0 #265 
  - type-fest с 3.0.0 на 3.1.0 #266 
  - @types/react-dom с 18.0.6 на 18.0.8 #268 