### PR TITLE
fix: state in dark theme for `#ffffff`

### DIFF
--- a/src/build/themeProcessors/expandColors/expandColors.ts
+++ b/src/build/themeProcessors/expandColors/expandColors.ts
@@ -33,11 +33,26 @@ const getColorWithStates = ({
 	colorState: Property.Color;
 	toneValueActive: number;
 	toneValueHover: number;
-}): ColorWithStates => ({
-	normal: colorArg,
-	hover: mixColors(colorArg, colorState, toneValueHover),
-	active: mixColors(colorArg, colorState, toneValueActive),
-});
+}): ColorWithStates => {
+	// Исправляет hover и action цвета в темной теме для белого цвета
+	if (
+		typeof colorArg === 'string' &&
+		colorArg.toLowerCase() === '#ffffff' &&
+		colorState === '#FFFFFF'
+	) {
+		return {
+			normal: '#FFFFFF',
+			hover: '#EBEDF0',
+			active: '#D7D8DB',
+		};
+	}
+
+	return {
+		normal: colorArg,
+		hover: mixColors(colorArg, colorState, toneValueHover),
+		active: mixColors(colorArg, colorState, toneValueActive),
+	};
+};
 
 function expandCallableColor<T extends {[key in keyof T]: ColorDescription}>(
 	color: ColorDescription<T>,

--- a/src/themeDescriptions/base/paradigm.ts
+++ b/src/themeDescriptions/base/paradigm.ts
@@ -144,11 +144,7 @@ export const darkColors: ColorsDescription = {
 	colors: {
 		// Background
 		colorBackgroundAccent: '#2775FC',
-		colorBackgroundAccentThemed: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorBackgroundAccentThemed: '#FFFFFF',
 		colorBackgroundAccentAlternative: '#FF9E00',
 		colorBackgroundContent: '#232324',
 		colorBackgroundSecondary: '#2A2A2B',
@@ -164,11 +160,7 @@ export const darkColors: ColorsDescription = {
 			active: 'rgba(255, 255, 255, 0.14)',
 		},
 		colorBackground: '#19191A',
-		colorBackgroundContrast: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorBackgroundContrast: '#FFFFFF',
 		colorBackgroundContrastSecondaryAlpha: {
 			normal: 'rgba(255, 255, 255, 0.2)',
 			hover: 'rgba(255, 255, 255, 0.24)',
@@ -181,28 +173,16 @@ export const darkColors: ColorsDescription = {
 		colorBackgroundNegativeTint: '#522e2e',
 		colorBackgroundPositiveTint: '#182A22',
 		colorFieldBackground: '#232324',
-		colorBackgroundModalInverse: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorBackgroundModalInverse: '#ffffff',
 		colorBackgroundContrastInverse: '#303030',
 		colorBackgroundAccentTint: '#5a9eff',
 
 		// Text
 		colorTextAccent: '#3C82FD',
-		colorTextAccentThemed: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorTextAccentThemed: '#FFFFFF',
 		colorTextNegative: '#ED0A34',
 		colorTextLink: '#589BFF',
-		colorTextLinkThemed: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorTextLinkThemed: '#FFFFFF',
 		colorTextMuted: '#E7E8EA',
 		colorTextPrimary: '#E7E8EA',
 		colorTextPrimaryInvariably: '#2C2D2E',
@@ -210,26 +190,14 @@ export const darkColors: ColorsDescription = {
 		colorTextSubhead: '#BFC1C5',
 		colorTextTertiary: '#74767A',
 		colorTextLinkVisited: '#528FDF',
-		colorTextContrast: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorTextContrast: '#FFFFFF',
 		colorTextContrastThemed: '#2C2D2E',
-		colorLinkContrast: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorLinkContrast: '#FFFFFF',
 		colorTextPositive: '#0DC268',
 
 		// Icons
 		colorIconAccent: '#3C82FD',
-		colorIconAccentThemed: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorIconAccentThemed: '#FFFFFF',
 		colorIconNegative: '#ED0A34',
 		colorIconPrimary: '#D9DADD',
 		colorIconPrimaryInvariably: '#2C2D2E',
@@ -239,27 +207,15 @@ export const darkColors: ColorsDescription = {
 		colorIconSecondaryAlpha: 'rgba(245, 246, 255, 0.6)',
 		colorIconTertiary: '#83848A',
 		colorIconTertiaryAlpha: 'rgba(245, 246, 255, 0.5)',
-		colorIconContrast: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorIconContrast: '#FFFFFF',
 		colorIconContrastThemed: '#2C2D2E',
 		colorIconPositive: '#0DC268',
 		colorIconContrastSecondary: '#F2F3F5',
 
 		// Stroke
 		colorStrokeAccent: '#3C82FD',
-		colorStrokeAccentThemed: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
-		colorStrokeContrast: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorStrokeAccentThemed: '#FFFFFF',
+		colorStrokeContrast: '#FFFFFF',
 		colorStrokeNegative: '#ED0A34',
 		colorImageBorderAlpha: 'rgba(255, 255, 255, 0.08)',
 		colorFieldBorderAlpha: 'rgba(255, 255, 255, 0.16)',

--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -167,11 +167,7 @@ export const darkColors: ColorsDescription = {
 	colors: {
 		// Background
 		colorBackgroundAccent: '#529EF4',
-		colorBackgroundAccentThemed: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorBackgroundAccentThemed: '#FFFFFF',
 		colorBackgroundAccentTint: '#5a9eff',
 		colorBackgroundAccentAlternative: '#529EF4',
 		colorBackground: '#0A0A0A',
@@ -188,11 +184,7 @@ export const darkColors: ColorsDescription = {
 			hover: 'rgba(255, 255, 255, 0.07)',
 			active: 'rgba(255, 255, 255, 0.11)',
 		},
-		colorBackgroundContrast: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorBackgroundContrast: '#FFFFFF',
 		colorBackgroundContrastSecondaryAlpha: {
 			normal: 'rgba(255, 255, 255, 0.2)',
 			hover: 'rgba(255, 255, 255, 0.24)',
@@ -200,11 +192,7 @@ export const darkColors: ColorsDescription = {
 		},
 		colorBackgroundContrastInverse: '#2d2d2e',
 		colorBackgroundModal: '#2D2D2E',
-		colorBackgroundModalInverse: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorBackgroundModalInverse: '#ffffff',
 		colorBackgroundWarning: '#857250',
 		colorBackgroundPositive: '#4BB34B',
 		colorBackgroundNegative: '#FF5C5C',
@@ -215,45 +203,25 @@ export const darkColors: ColorsDescription = {
 
 		// Text
 		colorTextAccent: '#529EF4',
-		colorTextAccentThemed: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorTextAccentThemed: '#FFFFFF',
 		colorTextPrimary: '#E1E3E6',
 		colorTextPrimaryInvariably: '#000000',
 		colorTextSecondary: '#76787A',
 		colorTextSubhead: '#969A9F',
 		colorTextTertiary: '#636567',
-		colorTextContrast: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorTextContrast: '#FFFFFF',
 		colorTextContrastThemed: '#000000',
 		colorTextPositive: '#4BB34B',
 		colorTextNegative: '#FF5C5C',
 		colorTextLink: '#529EF4',
-		colorTextLinkThemed: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorTextLinkThemed: '#FFFFFF',
 		colorTextLinkVisited: '#4986CC',
 		colorTextMuted: '#E1E3E6',
-		colorLinkContrast: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorLinkContrast: '#FFFFFF',
 
 		// Icons
 		colorIconAccent: '#529EF4',
-		colorIconAccentThemed: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorIconAccentThemed: '#FFFFFF',
 		colorIconPrimary: '#E1E3E6',
 		colorIconPrimaryInvariably: '#2C2D2E',
 		colorIconMedium: '#B0B1B6',
@@ -262,11 +230,7 @@ export const darkColors: ColorsDescription = {
 		colorIconSecondaryAlpha: 'rgba(0, 0, 0, 0.43)',
 		colorIconTertiary: '#5D5F61',
 		colorIconTertiaryAlpha: 'rgba(255, 255, 255, 0.3)',
-		colorIconContrast: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorIconContrast: '#FFFFFF',
 		colorIconContrastThemed: '#000000',
 		colorIconContrastSecondary: '#F2F3F5',
 		colorIconPositive: '#4BB34B',
@@ -274,11 +238,7 @@ export const darkColors: ColorsDescription = {
 
 		// Stroke
 		colorStrokeAccent: '#529EF4',
-		colorStrokeAccentThemed: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorStrokeAccentThemed: '#FFFFFF',
 		colorSeparatorPrimary: '#363738',
 		colorSeparatorPrimary2x: '#444546',
 		colorSeparatorPrimary3x: '#505253',
@@ -286,11 +246,7 @@ export const darkColors: ColorsDescription = {
 		colorSeparatorSecondary: '#141415',
 		colorStrokePositive: '#4BB34B',
 		colorStrokeNegative: '#FF5C5C',
-		colorStrokeContrast: {
-			normal: '#FFFFFF',
-			hover: '#EBEDF0',
-			active: '#D7D8DB',
-		},
+		colorStrokeContrast: '#FFFFFF',
 		colorImageBorderAlpha: 'rgba(255, 255, 255, 0.08)',
 		colorFieldBorderAlpha: 'rgba(255, 255, 255, 0.12)',
 


### PR DESCRIPTION
В темной теме цвета hover и active от `#ffffff` будут тем же `#ffffff`

<img width="1168" alt="image" src="https://user-images.githubusercontent.com/14944123/201638251-45d65bd5-2157-4374-9eb6-ea03d9e21735.png">

В #285 исправление было не полным, поэтому решил запихнуть исправление в `getColorWithStates`