### PR TITLE
4.29.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
     "@vkontakte/appearance": "https://github.com/VKCOM/Appearance#v9.51.4",
-    "@vkontakte/icons": "2.3.0",
+    "@vkontakte/icons": "2.14.0",
     "@vkontakte/prettier-config": "0.1.0",
     "@vkontakte/vk-bridge": "2.7.2",
     "@vkontakte/vkui": "4.40.0",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@vkontakte/vk-bridge": "2.7.2",
     "@vkontakte/vkui": "4.40.0",
     "babel-jest": "29.4.1",
-    "babel-loader": "9.1.0",
+    "babel-loader": "9.1.2",
     "clean-webpack-plugin": "4.0.0",
     "clsx": "1.2.1",
     "color": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vkui-tokens",
-  "version": "4.28.0",
+  "version": "4.29.0",
   "description": "Репозиторий, который содержит в себе дизайн-токены и другие инструменты объединенной дизайн-системы VKUI и Paradigm",
   "license": "MIT",
   "main": "utils/descriptions.js",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "@vkontakte/prettier-config": "0.1.0",
     "@vkontakte/vk-bridge": "2.7.2",
     "@vkontakte/vkui": "4.40.0",
-    "babel-jest": "29.3.1",
+    "babel-jest": "29.4.1",
     "babel-loader": "9.1.0",
     "clean-webpack-plugin": "4.0.0",
     "clsx": "1.2.1",

--- a/src/themeDescriptions/base/paradigm.ts
+++ b/src/themeDescriptions/base/paradigm.ts
@@ -167,7 +167,7 @@ export const darkColors: ColorsDescription = {
 			active: 'rgba(255, 255, 255, 0.28)',
 		},
 		colorBackgroundWarning: '#6C4E00',
-		colorBackgroundNegative: '#ED0A34',
+		colorBackgroundNegative: '#FF5C5C',
 		colorBackgroundModal: '#303030',
 		colorBackgroundPositive: '#0DC268',
 		colorBackgroundNegativeTint: '#522e2e',
@@ -180,7 +180,7 @@ export const darkColors: ColorsDescription = {
 		// Text
 		colorTextAccent: '#3C82FD',
 		colorTextAccentThemed: '#FFFFFF',
-		colorTextNegative: '#ED0A34',
+		colorTextNegative: '#FF5C5C',
 		colorTextLink: '#589BFF',
 		colorTextLinkThemed: '#FFFFFF',
 		colorTextMuted: '#E7E8EA',
@@ -198,7 +198,7 @@ export const darkColors: ColorsDescription = {
 		// Icons
 		colorIconAccent: '#3C82FD',
 		colorIconAccentThemed: '#FFFFFF',
-		colorIconNegative: '#ED0A34',
+		colorIconNegative: '#FF5C5C',
 		colorIconPrimary: '#D9DADD',
 		colorIconPrimaryInvariably: '#2C2D2E',
 		colorIconMedium: '#B0B1B6',
@@ -216,7 +216,7 @@ export const darkColors: ColorsDescription = {
 		colorStrokeAccent: '#3C82FD',
 		colorStrokeAccentThemed: '#FFFFFF',
 		colorStrokeContrast: '#FFFFFF',
-		colorStrokeNegative: '#ED0A34',
+		colorStrokeNegative: '#FF5C5C',
 		colorImageBorderAlpha: 'rgba(255, 255, 255, 0.08)',
 		colorFieldBorderAlpha: 'rgba(255, 255, 255, 0.16)',
 		colorSeparatorPrimaryAlpha: 'rgba(0, 0, 0, 0.4)',
@@ -346,8 +346,8 @@ export const lightThemeBase: ThemeDescription = {
 		regular: {
 			fontSize: 14,
 			lineHeight: 18,
-			fontFamily: fontFamilyBase,
-			fontWeight: fontWeightBase3,
+			fontFamily: fontFamilyAccent,
+			fontWeight: fontWeightAccent3,
 		},
 		compact: {
 			fontSize: 13,

--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -6,10 +6,8 @@ import { ColorsDescription, ThemeDescription } from '@/interfaces/general';
 import { Elevation } from '@/interfaces/general/elevation';
 import { Gradients } from '@/interfaces/general/gradients';
 
-const FONT_FAMILY_DEFAULT = 'VK Sans Text';
-
-const fontFamilyAccent = `"${FONT_FAMILY_DEFAULT}", -apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif`;
-const fontFamilyBase = `"${FONT_FAMILY_DEFAULT}", -apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif`;
+const fontFamilyAccent = `-apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif`;
+const fontFamilyBase = `-apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif`;
 const fontWeightAccent1 = 600;
 const fontWeightAccent2 = 500;
 const fontWeightAccent3 = 400;
@@ -310,7 +308,6 @@ export const lightTheme: ThemeDescription = {
 		regular: {
 			fontSize: 24,
 			lineHeight: 28,
-			letterSpacing: '-0.48px',
 			fontFamily: fontFamilyAccent,
 			fontWeight: fontWeightAccent1,
 		},
@@ -319,7 +316,6 @@ export const lightTheme: ThemeDescription = {
 		regular: {
 			fontSize: 20,
 			lineHeight: 24,
-			letterSpacing: '-0.4px',
 			fontFamily: fontFamilyAccent,
 			fontWeight: fontWeightAccent1,
 		},
@@ -328,7 +324,6 @@ export const lightTheme: ThemeDescription = {
 		regular: {
 			fontSize: 17,
 			lineHeight: 22,
-			letterSpacing: '-0.22px',
 			fontFamily: fontFamilyAccent,
 			fontWeight: fontWeightAccent1,
 		},
@@ -338,49 +333,42 @@ export const lightTheme: ThemeDescription = {
 		regular: {
 			fontSize: 16,
 			lineHeight: 20,
-			letterSpacing: '-0.16px',
 			fontFamily: fontFamilyAccent,
 			fontWeight: fontWeightAccent2,
 		},
 		compact: {
 			fontSize: 15,
 			lineHeight: 20,
-			letterSpacing: '-0.1px',
 		},
 	},
 	fontHeadline2: {
 		regular: {
 			fontSize: 15,
 			lineHeight: 20,
-			letterSpacing: '-0.1px',
 			fontFamily: fontFamilyAccent,
 			fontWeight: fontWeightAccent2,
 		},
 		compact: {
 			fontSize: 14,
 			lineHeight: 20,
-			letterSpacing: '-0.06px',
 		},
 	},
 	fontText: {
 		regular: {
 			fontSize: 16,
 			lineHeight: 20,
-			letterSpacing: '-0.16px',
 			fontFamily: fontFamilyBase,
 			fontWeight: fontWeightBase3,
 		},
 		compact: {
 			fontSize: 15,
 			lineHeight: 20,
-			letterSpacing: '-0.1px',
 		},
 	},
 	fontParagraph: {
 		regular: {
 			fontSize: 15,
 			lineHeight: 20,
-			letterSpacing: '-0.1px',
 			fontFamily: fontFamilyBase,
 			fontWeight: fontWeightBase3,
 		},
@@ -389,21 +377,18 @@ export const lightTheme: ThemeDescription = {
 		regular: {
 			fontSize: 14,
 			lineHeight: 18,
-			letterSpacing: '-0.06px',
 			fontFamily: fontFamilyBase,
 			fontWeight: fontWeightBase3,
 		},
 		compact: {
 			fontSize: 13,
 			lineHeight: 16,
-			letterSpacing: '0px',
 		},
 	},
 	fontFootnote: {
 		regular: {
 			fontSize: 13,
 			lineHeight: 16,
-			letterSpacing: '0px',
 			fontFamily: fontFamilyBase,
 			fontWeight: fontWeightBase3,
 		},
@@ -412,7 +397,6 @@ export const lightTheme: ThemeDescription = {
 		regular: {
 			fontSize: 13,
 			lineHeight: 16,
-			letterSpacing: '0.3px',
 			fontFamily: fontFamilyBase,
 			fontWeight: fontWeightBase3,
 			textTransform: 'uppercase',
@@ -422,7 +406,6 @@ export const lightTheme: ThemeDescription = {
 		regular: {
 			fontSize: 12,
 			lineHeight: 14,
-			letterSpacing: '0.06px',
 			fontFamily: fontFamilyBase,
 			fontWeight: fontWeightBase3,
 		},
@@ -431,7 +414,6 @@ export const lightTheme: ThemeDescription = {
 		regular: {
 			fontSize: 12,
 			lineHeight: 14,
-			letterSpacing: '0.2px',
 			fontFamily: fontFamilyBase,
 			fontWeight: fontWeightBase1,
 			textTransform: 'uppercase',
@@ -441,7 +423,6 @@ export const lightTheme: ThemeDescription = {
 		regular: {
 			fontSize: 11,
 			lineHeight: 14,
-			letterSpacing: '0.11px',
 			fontFamily: fontFamilyBase,
 			fontWeight: fontWeightBase3,
 		},
@@ -450,7 +431,6 @@ export const lightTheme: ThemeDescription = {
 		regular: {
 			fontSize: 11,
 			lineHeight: 14,
-			letterSpacing: '0.3px',
 			fontFamily: fontFamilyBase,
 			fontWeight: fontWeightBase1,
 			textTransform: 'uppercase',
@@ -460,7 +440,6 @@ export const lightTheme: ThemeDescription = {
 		regular: {
 			fontSize: 9,
 			lineHeight: 12,
-			letterSpacing: '0.18px',
 			fontFamily: fontFamilyBase,
 			fontWeight: fontWeightBase3,
 		},
@@ -469,7 +448,6 @@ export const lightTheme: ThemeDescription = {
 		regular: {
 			fontSize: 9,
 			lineHeight: 12,
-			letterSpacing: '0.3px',
 			fontFamily: fontFamilyBase,
 			fontWeight: fontWeightBase1,
 			textTransform: 'uppercase',

--- a/src/themeDescriptions/themes/vkCom/index.ts
+++ b/src/themeDescriptions/themes/vkCom/index.ts
@@ -156,6 +156,10 @@ export const vkComTheme: ThemeVkComDescription = {
 		regular: 12,
 	},
 
+	sizePopupSmall: {
+		regular: 448,
+	},
+
 	// Компонент Switch
 	sizeSwitchHeight: {
 		regular: 10,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1256,6 +1256,13 @@
   dependencies:
     "@sinclair/typebox" "^0.24.1"
 
+"@jest/schemas@^29.4.0":
+  version "29.4.0"
+  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.4.0.tgz#0d6ad358f295cc1deca0b643e6b4c86ebd539f17"
+  integrity sha512-0E01f/gOZeNTG76i5eWWSupvSHaIINrTie7vCyjiYFKgzNdyEGd12BUv4oNBFHOqlHDbtoJi3HrQ38KCC90NsQ==
+  dependencies:
+    "@sinclair/typebox" "^0.25.16"
+
 "@jest/source-map@^29.2.0":
   version "29.2.0"
   resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-29.2.0.tgz#ab3420c46d42508dcc3dc1c6deee0b613c235744"
@@ -1285,26 +1292,26 @@
     jest-haste-map "^29.3.1"
     slash "^3.0.0"
 
-"@jest/transform@^29.3.1":
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.3.1.tgz#1e6bd3da4af50b5c82a539b7b1f3770568d6e36d"
-  integrity sha512-8wmCFBTVGYqFNLWfcOWoVuMuKYPUBTnTMDkdvFtAYELwDOl9RGwOsvQWGPFxDJ8AWY9xM/8xCXdqmPK3+Q5Lug==
+"@jest/transform@^29.3.1", "@jest/transform@^29.4.1":
+  version "29.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/transform/-/transform-29.4.1.tgz#e4f517841bb795c7dcdee1ba896275e2c2d26d4a"
+  integrity sha512-5w6YJrVAtiAgr0phzKjYd83UPbCXsBRTeYI4BXokv9Er9CcrH9hfXL/crCvP2d2nGOcovPUnlYiLPFLZrkG5Hg==
   dependencies:
     "@babel/core" "^7.11.6"
-    "@jest/types" "^29.3.1"
+    "@jest/types" "^29.4.1"
     "@jridgewell/trace-mapping" "^0.3.15"
     babel-plugin-istanbul "^6.1.1"
     chalk "^4.0.0"
     convert-source-map "^2.0.0"
     fast-json-stable-stringify "^2.1.0"
     graceful-fs "^4.2.9"
-    jest-haste-map "^29.3.1"
+    jest-haste-map "^29.4.1"
     jest-regex-util "^29.2.0"
-    jest-util "^29.3.1"
+    jest-util "^29.4.1"
     micromatch "^4.0.4"
     pirates "^4.0.4"
     slash "^3.0.0"
-    write-file-atomic "^4.0.1"
+    write-file-atomic "^5.0.0"
 
 "@jest/types@^29.3.1":
   version "29.3.1"
@@ -1312,6 +1319,18 @@
   integrity sha512-d0S0jmmTpjnhCmNpApgX3jrUZgZ22ivKJRvL2lli5hpCRoNnp1f85r2/wpKfXuYu8E7Jjh1hGfhPyup1NM5AmA==
   dependencies:
     "@jest/schemas" "^29.0.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^17.0.8"
+    chalk "^4.0.0"
+
+"@jest/types@^29.4.1":
+  version "29.4.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.4.1.tgz#f9f83d0916f50696661da72766132729dcb82ecb"
+  integrity sha512-zbrAXDUOnpJ+FMST2rV7QZOgec8rskg2zv8g2ajeqitp4tvZiyqTCYXANrKsM+ryj5o+LI+ZN2EgU9drrkiwSA==
+  dependencies:
+    "@jest/schemas" "^29.4.0"
     "@types/istanbul-lib-coverage" "^2.0.0"
     "@types/istanbul-reports" "^3.0.0"
     "@types/node" "*"
@@ -1455,6 +1474,11 @@
   version "0.24.51"
   resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.51.tgz#645f33fe4e02defe26f2f5c0410e1c094eac7f5f"
   integrity sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==
+
+"@sinclair/typebox@^0.25.16":
+  version "0.25.21"
+  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.25.21.tgz#763b05a4b472c93a8db29b2c3e359d55b29ce272"
+  integrity sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"
@@ -2466,15 +2490,15 @@ axobject-query@^2.2.0:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
-babel-jest@29.3.1, babel-jest@^29.3.1:
-  version "29.3.1"
-  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.3.1.tgz#05c83e0d128cd48c453eea851482a38782249f44"
-  integrity sha512-aard+xnMoxgjwV70t0L6wkW/3HQQtV+O0PEimxKgzNqCJnbYmroPojdP2tqKSOAt8QAKV/uSZU8851M7B5+fcA==
+babel-jest@29.4.1, babel-jest@^29.3.1:
+  version "29.4.1"
+  resolved "https://registry.yarnpkg.com/babel-jest/-/babel-jest-29.4.1.tgz#01fa167e27470b35c2d4a1b841d9586b1764da19"
+  integrity sha512-xBZa/pLSsF/1sNpkgsiT3CmY7zV1kAsZ9OxxtrFqYucnOuRftXAfcJqcDVyOPeN4lttWTwhLdu0T9f8uvoPEUg==
   dependencies:
-    "@jest/transform" "^29.3.1"
+    "@jest/transform" "^29.4.1"
     "@types/babel__core" "^7.1.14"
     babel-plugin-istanbul "^6.1.1"
-    babel-preset-jest "^29.2.0"
+    babel-preset-jest "^29.4.0"
     chalk "^4.0.0"
     graceful-fs "^4.2.9"
     slash "^3.0.0"
@@ -2498,10 +2522,10 @@ babel-plugin-istanbul@^6.1.1:
     istanbul-lib-instrument "^5.0.4"
     test-exclude "^6.0.0"
 
-babel-plugin-jest-hoist@^29.2.0:
-  version "29.2.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.2.0.tgz#23ee99c37390a98cfddf3ef4a78674180d823094"
-  integrity sha512-TnspP2WNiR3GLfCsUNHqeXw0RoQ2f9U5hQ5L3XFpwuO8htQmSrhh8qsB6vi5Yi8+kuynN1yjDjQsPfkebmB6ZA==
+babel-plugin-jest-hoist@^29.4.0:
+  version "29.4.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.4.0.tgz#3fd3dfcedf645932df6d0c9fc3d9a704dd860248"
+  integrity sha512-a/sZRLQJEmsmejQ2rPEUe35nO1+C9dc9O1gplH1SXmJxveQSRUYdBk8yGZG/VOUuZs1u2aHZJusEGoRMbhhwCg==
   dependencies:
     "@babel/template" "^7.3.3"
     "@babel/types" "^7.3.3"
@@ -2550,12 +2574,12 @@ babel-preset-current-node-syntax@^1.0.0:
     "@babel/plugin-syntax-optional-chaining" "^7.8.3"
     "@babel/plugin-syntax-top-level-await" "^7.8.3"
 
-babel-preset-jest@^29.2.0:
-  version "29.2.0"
-  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-29.2.0.tgz#3048bea3a1af222e3505e4a767a974c95a7620dc"
-  integrity sha512-z9JmMJppMxNv8N7fNRHvhMg9cvIkMxQBXgFkane3yKVEvEOP+kB50lk8DFRvF9PGqbyXxlmebKWhuDORO8RgdA==
+babel-preset-jest@^29.4.0:
+  version "29.4.0"
+  resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-29.4.0.tgz#c2b03c548b02dea0a18ae21d5759c136f9251ee4"
+  integrity sha512-fUB9vZflUSM3dO/6M2TCAepTzvA4VkOvl67PjErcrQMGt9Eve7uazaeyCZ2th3UtI7ljpiBJES0F7A1vBRsLZA==
   dependencies:
-    babel-plugin-jest-hoist "^29.2.0"
+    babel-plugin-jest-hoist "^29.4.0"
     babel-preset-current-node-syntax "^1.0.0"
 
 balanced-match@^1.0.0:
@@ -5261,6 +5285,25 @@ jest-haste-map@^29.3.1:
   optionalDependencies:
     fsevents "^2.3.2"
 
+jest-haste-map@^29.4.1:
+  version "29.4.1"
+  resolved "https://registry.yarnpkg.com/jest-haste-map/-/jest-haste-map-29.4.1.tgz#b0579dc82d94b40ed9041af56ad25c2f80bedaeb"
+  integrity sha512-imTjcgfVVTvg02khXL11NNLTx9ZaofbAWhilrMg/G8dIkp+HYCswhxf0xxJwBkfhWb3e8dwbjuWburvxmcr58w==
+  dependencies:
+    "@jest/types" "^29.4.1"
+    "@types/graceful-fs" "^4.1.3"
+    "@types/node" "*"
+    anymatch "^3.0.3"
+    fb-watchman "^2.0.0"
+    graceful-fs "^4.2.9"
+    jest-regex-util "^29.2.0"
+    jest-util "^29.4.1"
+    jest-worker "^29.4.1"
+    micromatch "^4.0.4"
+    walker "^1.0.8"
+  optionalDependencies:
+    fsevents "^2.3.2"
+
 jest-junit@15.0.0:
   version "15.0.0"
   resolved "https://registry.yarnpkg.com/jest-junit/-/jest-junit-15.0.0.tgz#a47544ab42e9f8fe7ada56306c218e09e52bd690"
@@ -5443,6 +5486,18 @@ jest-util@^29.0.0, jest-util@^29.3.1:
     graceful-fs "^4.2.9"
     picomatch "^2.2.3"
 
+jest-util@^29.4.1:
+  version "29.4.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.4.1.tgz#2eeed98ff4563b441b5a656ed1a786e3abc3e4c4"
+  integrity sha512-bQy9FPGxVutgpN4VRc0hk6w7Hx/m6L53QxpDreTZgJd9gfx/AV2MjyPde9tGyZRINAUrSv57p2inGBu2dRLmkQ==
+  dependencies:
+    "@jest/types" "^29.4.1"
+    "@types/node" "*"
+    chalk "^4.0.0"
+    ci-info "^3.2.0"
+    graceful-fs "^4.2.9"
+    picomatch "^2.2.3"
+
 jest-validate@^29.3.1:
   version "29.3.1"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-29.3.1.tgz#d56fefaa2e7d1fde3ecdc973c7f7f8f25eea704a"
@@ -5485,6 +5540,16 @@ jest-worker@^29.3.1:
   dependencies:
     "@types/node" "*"
     jest-util "^29.3.1"
+    merge-stream "^2.0.0"
+    supports-color "^8.0.0"
+
+jest-worker@^29.4.1:
+  version "29.4.1"
+  resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-29.4.1.tgz#7cb4a99a38975679600305650f86f4807460aab1"
+  integrity sha512-O9doU/S1EBe+yp/mstQ0VpPwpv0Clgn68TkNwGxL6/usX/KUW9Arnn4ag8C3jc6qHcXznhsT5Na1liYzAsuAbQ==
+  dependencies:
+    "@types/node" "*"
+    jest-util "^29.4.1"
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
@@ -8167,10 +8232,10 @@ wrappy@1:
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
-write-file-atomic@^4.0.1:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-4.0.2.tgz#a9df01ae5b77858a027fd2e80768ee433555fcfd"
-  integrity sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==
+write-file-atomic@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-5.0.0.tgz#54303f117e109bf3d540261125c8ea5a7320fab0"
+  integrity sha512-R7NYMnHSlV42K54lwY9lvW6MnSm1HSJqZL3xiSgi9E7//FYaI74r2G0rd+/X6VAMkHEdzxQaU5HUOXWUz5kA/w==
   dependencies:
     imurmurhash "^0.1.4"
     signal-exit "^3.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2010,10 +2010,10 @@
   version "1.0.0"
   resolved "https://github.com/VKCOM/Appearance#b38b6c9448c79d39f2618cfb821e7199e82e8f38"
 
-"@vkontakte/icons@2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@vkontakte/icons/-/icons-2.3.0.tgz#ab0474268c5727b78558ed817aa5d6430cc264b7"
-  integrity sha512-VRnwu7R/Fi42ghnb08MMT8kaa1xigR9IzaBP8R+nNb5klORGfWB8OVnRNpEoGWbJDqT6IR/+89Qc7E593ND8rw==
+"@vkontakte/icons@2.14.0":
+  version "2.14.0"
+  resolved "https://registry.yarnpkg.com/@vkontakte/icons/-/icons-2.14.0.tgz#3bfa8340f24496a886f1eea84e792e1a70e3e462"
+  integrity sha512-uipsIzPFYymniXuu2no/NKeW8M/u+6JqZOskK0me58ckZY8jQP52QtZKdEpC6pQmtNacipsb/aj9G5wSLlJqlg==
   dependencies:
     svg-baker-runtime "1.4.7"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2503,10 +2503,10 @@ babel-jest@29.4.1, babel-jest@^29.3.1:
     graceful-fs "^4.2.9"
     slash "^3.0.0"
 
-babel-loader@9.1.0:
-  version "9.1.0"
-  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-9.1.0.tgz#839e9ae88aea930864ef9ec0f356dfca96ecf238"
-  integrity sha512-Antt61KJPinUMwHwIIz9T5zfMgevnfZkEVWYDWlG888fgdvRRGD0JTuf/fFozQnfT+uq64sk1bmdHDy/mOEWnA==
+babel-loader@9.1.2:
+  version "9.1.2"
+  resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-9.1.2.tgz#a16a080de52d08854ee14570469905a5fc00d39c"
+  integrity sha512-mN14niXW43tddohGl8HPu5yfQq70iUThvFL/4QzESA7GcZoC0eVOhvWdQ8+3UlSjaDE9MVtsW9mxDY07W7VpVA==
   dependencies:
     find-cache-dir "^3.3.2"
     schema-utils "^4.0.0"


### PR DESCRIPTION
**Изменённые токены**
- Исправлен токен `sizePopupSmall` в базовой теме `vkCom` #380 @SevereCloud 
- Исправлены токены в базовой теме `paradigm`: #375 @Fliqle 
  -  `colorBackgroundNegative` 
  -  `colorTextNegative`
  -  `colorIconNegative`
  -  `colorStrokeNegative`
- Шрифт MailSans установлен по умолчанию для всех токенов базовой темы `paradigm` #375 @Fliqle 

**Инфраструктура**
- Изменены версии devDeps:
  - @vkontakte/icons с 2.3.0 на 2.14.0 #383
  -  babel-jest с 29.3.1 на 29.4.1 #377