### PR TITLE
feat(vkBase): use `VK Sans Display` for `fontFamilyAccent`

### DIFF
--- a/docs/src/components/pages/Tokens/TokensContent/TokensContent.helpers.ts
+++ b/docs/src/components/pages/Tokens/TokensContent/TokensContent.helpers.ts
@@ -1,4 +1,4 @@
-import { TokenItem, TokenItemValue } from '@/shared/types';
+import type { Description, TokenItem, TokenItemValue } from '@/shared/types';
 
 export function filterByTags(selectedTags: Array<string>, token: TokenItem): boolean {
 	// Исключаем legacy-токены по умолчанию, если не запросили явно
@@ -13,8 +13,8 @@ export function filterByTags(selectedTags: Array<string>, token: TokenItem): boo
 	return selectedTags.some((sTag) => token.tags.includes(sTag));
 }
 
-function containsInDesc(haystack: string, needle: string): boolean {
-	return haystack.toLowerCase().includes(needle);
+function containsInDesc(haystacks: Description[], needle: string): boolean {
+	return haystacks.some((haystack) => haystack.text.toLowerCase().includes(needle));
 }
 
 function containsInValue(haystack: TokenItemValue, needle: string): boolean {

--- a/docs/src/components/pages/Tokens/TokensContent/TokensContent.tsx
+++ b/docs/src/components/pages/Tokens/TokensContent/TokensContent.tsx
@@ -2,10 +2,16 @@ import './TokensContent.css';
 
 import { Icon20CopyOutline } from '@vkontakte/icons';
 import { copyTextToClipboard } from '@vkontakte/vkjs';
-import { Button, Paragraph, Separator, useAdaptivityWithJSMediaQueries } from '@vkontakte/vkui';
-import React, { FC, useMemo } from 'react';
+import {
+	Button,
+	Link,
+	Paragraph,
+	Separator,
+	useAdaptivityWithJSMediaQueries,
+} from '@vkontakte/vkui';
+import React, { FC, Fragment, useMemo } from 'react';
 
-import { Tokens, ValueType } from '@/shared/types';
+import type { Description, Tokens, ValueType } from '@/shared/types';
 
 import TokensContentValue from './components/TokensContentValue';
 import { filterByDesc, filterByTags } from './TokensContent.helpers';
@@ -16,6 +22,23 @@ type Props = {
 	selectedValueType: ValueType;
 	searchValue: string;
 };
+
+function mapTokenDescription(descriptions: Description[]) {
+	return descriptions.map((description, uniqueIndex) => {
+		switch (description.type) {
+			case 'text':
+				return <Fragment key={uniqueIndex}>{description.text}</Fragment>;
+			case 'link':
+				return (
+					<Link key={uniqueIndex} href={description.url}>
+						{description.text}
+					</Link>
+				);
+			default:
+				return null;
+		}
+	});
+}
 
 const TokensContent: FC<Props> = ({ tokens, selectedTags, selectedValueType, searchValue }) => {
 	const { viewWidth } = useAdaptivityWithJSMediaQueries();
@@ -70,12 +93,14 @@ const TokensContent: FC<Props> = ({ tokens, selectedTags, selectedValueType, sea
 							</div>
 							{isTabletPlus && (
 								<div>
-									<Paragraph>{tokens[token].desc || '-'}</Paragraph>
+									<Paragraph>
+										{tokens[token].desc.length > 0 ? mapTokenDescription(tokens[token].desc) : '-'}
+									</Paragraph>
 								</div>
 							)}
 							{!isTabletPlus && !!tokens[token].desc && (
 								<div>
-									<Paragraph>{tokens[token].desc}</Paragraph>
+									<Paragraph>{mapTokenDescription(tokens[token].desc)}</Paragraph>
 								</div>
 							)}
 						</div>

--- a/docs/src/shared/types/tokens.ts
+++ b/docs/src/shared/types/tokens.ts
@@ -11,9 +11,20 @@ type TokenItemValueObject = {
 
 export type TokenItemValue = string | number | TokenItemValueObject;
 
+export type Description =
+	| {
+			type: 'text';
+			text: string;
+	  }
+	| {
+			type: 'link';
+			url: string;
+			text: string;
+	  };
+
 export type TokenItem = {
 	tags: Array<string>;
-	desc: string;
+	desc: Description[];
 	value: TokenItemValue;
 };
 

--- a/src/build/compilers/docs/__test__/testLinks.ts
+++ b/src/build/compilers/docs/__test__/testLinks.ts
@@ -1,0 +1,7 @@
+export interface BaseTheme {
+	/**
+	 * @desc Link with text {@link https://google.com Google}.
+	 *       Link without text {@link https://google.com}
+	 */
+	importedBaseProp: string;
+}

--- a/src/build/compilers/docs/compileDocsJSON.test.ts
+++ b/src/build/compilers/docs/compileDocsJSON.test.ts
@@ -9,8 +9,43 @@ describe('compileDocsJSON', () => {
 
 		expect(docs).toEqual({
 			importedBaseProp: {
-				desc: 'Short desc tag',
+				desc: [
+					{
+						type: 'text',
+						text: 'Short desc tag',
+					},
+				],
 				tags: ['tag1', 'tag2'],
+			},
+		});
+	});
+
+	it('should correct compile documentation with jsdoc link', () => {
+		const docs = getTypeDocs('src/build/compilers/docs/__test__/testLinks.ts', 'BaseTheme');
+
+		expect(docs).toEqual({
+			importedBaseProp: {
+				desc: [
+					{
+						type: 'text',
+						text: 'Link with text ',
+					},
+					{
+						type: 'link',
+						url: 'https://google.com',
+						text: 'Google',
+					},
+					{
+						type: 'text',
+						text: '.\nLink without text ',
+					},
+					{
+						type: 'link',
+						url: 'https://google.com',
+						text: 'https://google.com',
+					},
+				],
+				tags: [],
 			},
 		});
 	});
@@ -20,23 +55,23 @@ describe('compileDocsJSON', () => {
 
 		expect(docs).toEqual({
 			prop: {
-				desc: '',
+				desc: [],
 				tags: ['empty description'],
 			},
 			propWithoutDoc: {
-				desc: '',
+				desc: [],
 				tags: [],
 			},
 			localBaseProp: {
-				desc: 'Empty tags',
+				desc: [{ type: 'text', text: 'Empty tags' }],
 				tags: [],
 			},
 			importedBaseProp: {
-				desc: 'Short desc tag',
+				desc: [{ type: 'text', text: 'Short desc tag' }],
 				tags: ['tag1', 'tag2'],
 			},
 			derivedProp: {
-				desc: 'Long description tag',
+				desc: [{ type: 'text', text: 'Long description tag' }],
 				tags: ['tagListItem1', 'tagListItem2', 'tagListItem3'],
 			},
 		});

--- a/src/build/index.ts
+++ b/src/build/index.ts
@@ -40,6 +40,12 @@ console.log('успешно\n');
 
 console.log('Начинаем процесс компиляции тем...\n');
 
+console.log('Копируем директорию src/shared...');
+const SHARED_PATH_SOURCE = path.resolve(ROOT_DIR, 'src/shared');
+const SHARED_PATH_DIST = path.resolve(DIST_PATH, 'shared');
+fs.copySync(SHARED_PATH_SOURCE, SHARED_PATH_DIST);
+console.log('успешно\n');
+
 const expandedThemes = themes.map(expandAll);
 const expandedThemesMap: Record<string, typeof expandedThemes[0]> = {};
 

--- a/src/interfaces/themes/vkBase/index.ts
+++ b/src/interfaces/themes/vkBase/index.ts
@@ -1,6 +1,15 @@
 import { Theme, ThemeCssVars, ThemeDescription } from '@/interfaces/general';
 
-export interface ThemeVkBase extends Theme {}
+export interface ThemeVkBase extends Theme {
+	/**
+	 * @desc Семейство шрифтов для заголовков.
+	 *       Как название по умолчанию, используется {@link https://github.com/VKCOM/vkui-tokens/tree/master/src/shared/constants.ts#:~:text=DEFAULT_FONT_FAMILY_ACCENT DEFAULT_FONT_FAMILY_ACCENT}.
+	 *       Привяжитесь к нему в своём font-face, чтобы загрузить необходимый вам шрифт.
+	 * @tags font
+	 */
+	fontFamilyAccent: Theme['fontFamilyAccent'];
+}
+
 export interface ThemeVkBaseDescription extends ThemeDescription {}
 
 export interface ThemeVkBaseCssVars extends ThemeCssVars {}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,0 +1,12 @@
+/**
+ * На стороне проекта нужно самостоятельно загружать необходимый файл шрифтов.
+ *
+ * @example
+ * ```css
+ * 	@font-face {
+ * 	  font-family: 'VK Sans Display',
+ * 	  src:  url("my-awesome-font.woff2") format("woff2");
+ * 	}
+ * ```
+ */
+export const DEFAULT_FONT_FAMILY_ACCENT = 'VK Sans Display';

--- a/src/shared/lib/guards.ts
+++ b/src/shared/lib/guards.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function isNotFunction<T>(value: T): value is Exclude<T, Function> {
+	return typeof value !== 'function';
+}

--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -5,8 +5,9 @@ import { alias } from '@/build/helpers/tokenHelpers';
 import { ColorsDescription, ThemeDescription } from '@/interfaces/general';
 import { Elevation } from '@/interfaces/general/elevation';
 import { Gradients } from '@/interfaces/general/gradients';
+import { DEFAULT_FONT_FAMILY_ACCENT } from '@/shared/constants';
 
-const fontFamilyAccent = `-apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif`;
+const fontFamilyAccent = `"${DEFAULT_FONT_FAMILY_ACCENT}", -apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif`;
 const fontFamilyBase = `-apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif`;
 const fontWeightAccent1 = 600;
 const fontWeightAccent2 = 500;

--- a/src/themeDescriptions/themes/vkCom/index.ts
+++ b/src/themeDescriptions/themes/vkCom/index.ts
@@ -4,6 +4,7 @@ import { alias } from '@/build/helpers/tokenHelpers';
 import { ColorsDescription } from '@/interfaces/general';
 import { ThemeVkComDescription } from '@/interfaces/themes/vkCom';
 import { ThemeVkComDarkDescription } from '@/interfaces/themes/vkComDark';
+import { isNotFunction } from '@/shared/lib/guards';
 import {
 	darkColors,
 	darkElevation,
@@ -13,11 +14,6 @@ import {
 } from '@/themeDescriptions/base/vk';
 
 import { resolveColor } from './appearance';
-
-const fontFamilyAccent = '-apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif';
-const fontFamilyBase = '-apple-system, system-ui, "Helvetica Neue", Roboto, sans-serif';
-const fontWeightAccent2 = 500;
-const fontWeightBase3 = 400;
 
 const vkComColors = (theme: typeof vkcom_light) => ({
 	// Background
@@ -167,8 +163,12 @@ export const vkComTheme: ThemeVkComDescription = {
 		regular: {
 			fontSize: 16,
 			lineHeight: 20,
-			fontFamily: fontFamilyAccent,
-			fontWeight: fontWeightAccent2,
+			fontFamily: isNotFunction(lightTheme.fontFamilyAccent)
+				? lightTheme.fontFamilyAccent
+				: undefined,
+			fontWeight: isNotFunction(lightTheme.fontWeightAccent2)
+				? lightTheme.fontWeightAccent2
+				: undefined,
 		},
 		compact: {
 			fontSize: 14,
@@ -180,8 +180,10 @@ export const vkComTheme: ThemeVkComDescription = {
 		regular: {
 			fontSize: 16,
 			lineHeight: 20,
-			fontFamily: fontFamilyBase,
-			fontWeight: fontWeightBase3,
+			fontFamily: isNotFunction(lightTheme.fontFamilyBase) ? lightTheme.fontFamilyBase : undefined,
+			fontWeight: isNotFunction(lightTheme.fontWeightAccent3)
+				? lightTheme.fontWeightAccent3
+				: undefined,
 		},
 		compact: {
 			fontSize: 13,


### PR DESCRIPTION
## Описание

- Добавил возможость использовать [jsdoc {@link}](https://jsdoc.app/tags-inline-link.html).
- Удалил копипаст значений типографики в `themeDescriptions/themes/vkCom` – вытаскиваю из базовой `lightTheme` (caused by #333)
- Создал папку `@/shared/constants`, чтобы шарить константы.
- Перебиваю базовый **jsdoc** для `fontFamilyAccent` в `src/interfaces/themes/vkBase/index.ts`. 
- В связи с предыдущем пунктом, добавил сортировку по алфавиту, т.к. `fontFamilyAccent` выносится в самый верх из-за перебития.

Пример:
<img width="1185" alt="image" src="https://user-images.githubusercontent.com/5850354/217810778-e5cddb8e-61a6-453c-b144-6e0478a9628d.png">

---

- close #376

---

Перед отправкой этого реквеста на ревью убедитесь, что:

- в вашей ветке работает сборка (`npm run build:local`),
- в вашей ветке проходят тесты (`npm test`),
- в вашей ветке проходит линтер (`npm run lint`), некоторые ошибки можно автоматически поправить с помощью `npm run lint:fix`,
- покрытие тестов не ниже минимального значения,
- если вы вносите изменения в задокументированные части библиотеки,
  ваш pull request содержит обновления документации,
- если вы вносите изменения в сами токены, вы
  согласовали их с дизайнерами.

[Подробнее о внесении изменений в репозиторий токенов](https://github.com/VKCOM/vkui-tokens/blob/master/CONTRIBUTING.md)
