### PR TITLE
Change size Subhead Compact size 13 → 14 for vkCom

### DIFF
--- a/src/themeDescriptions/themes/vkCom/index.ts
+++ b/src/themeDescriptions/themes/vkCom/index.ts
@@ -176,6 +176,19 @@ export const vkComTheme: ThemeVkComDescription = {
 		},
 	},
 
+	fontSubhead: {
+		regular: {
+			fontSize: 14,
+			lineHeight: 18,
+			fontFamily: fontFamilyBase,
+			fontWeight: fontWeightBase3,
+		},
+		compact: {
+			fontSize: 14,
+			lineHeight: 18,
+		},
+	},
+
 	fontText: {
 		regular: {
 			fontSize: 16,


### PR DESCRIPTION
Добавлен размер Subhead типографики 14px, для команды VKCOM Kit, чтобы использовать одинаковые размеры Regular и Compact в компонентах Kit'а