### PR TITLE
ci(coverage.yml): use yarn

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,8 +11,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: 18
+          cache: 'yarn'
       - uses: artiomtr/jest-coverage-report-action@v2.0-rc.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           annotations: coverage
+          package-manager: yarn


### PR DESCRIPTION
## Что делает PR?

Правит ошибку в воркфлоу `coverage.yml`

<img width="320" alt="image" src="https://user-images.githubusercontent.com/5850354/219084424-a73364de-2d1e-4dd6-ad73-722ab9f4576e.png">

**Рис. 1** Пример из https://github.com/VKCOM/vkui-tokens/actions/runs/4141331319/jobs/7160817364

## Из-за чего возникает ошибка?

**Node >= 18** устанавливает **NPM v9**, поэтому `npm` начал ругаться, что установленная версия не совпадает с тем, что прописано в `engines` в  `package.json`:

https://github.com/VKCOM/vkui-tokens/blob/c2f3f5f1bcf5c92c5bfb0732da81bd88072ce5c2/package.json#L96-L97

при этом ошибка не воспроизводилась **Node <= 18.13.0**, а с **Node 18.14.0** начал ругаться.

## Как решили проблему?

Решили через использование `yarn`. Что правильней, т.к. в проекте используется именно этот пакетный менеджер. `npm` не умеет в `yarn.lock`.

---

- related #297 (в этом PR для CI начали использовать `node-version 18`)

---

Перед отправкой этого реквеста на ревью убедитесь, что:

- в вашей ветке работает сборка (`npm run build:local`),
- в вашей ветке проходят тесты (`npm test`),
- в вашей ветке проходит линтер (`npm run lint`), некоторые ошибки можно автоматически поправить с помощью `npm run lint:fix`,
- покрытие тестов не ниже минимального значения,
- если вы вносите изменения в задокументированные части библиотеки,
  ваш pull request содержит обновления документации,
- если вы вносите изменения в сами токены, вы
  согласовали их с дизайнерами.

[Подробнее о внесении изменений в репозиторий токенов](https://github.com/VKCOM/vkui-tokens/blob/master/CONTRIBUTING.md)
