### PR TITLE
ci: remove vkui-core from dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
       - dependency-type: 'direct'
     reviewers:
       - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'
   - package-ecosystem: 'github-actions'
     # Workflow files stored in the
     # default location of `.github/workflows`
@@ -17,4 +16,3 @@ updates:
       interval: 'daily'
     reviewers:
       - 'VKCOM/vk-sec'
-      - 'VKCOM/vkui-core'


### PR DESCRIPTION
Удаляем из dependabot.yml @VKCOM/vkui-core
