### PR TITLE
chore: up dependabot limit + add groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,26 @@ updates:
       interval: 'daily'
     allow:
       - dependency-type: 'direct'
+    open-pull-requests-limit: 10
+    groups:
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+          - '@types/react'
+          - '@types/react-dom'
+    eslint:
+      patterns:
+        - 'eslint*'
+    jest:
+      patterns:
+        - 'jest*'
+        - '@types/jest*'
+        - 'babel-jest'
+    prettier:
+      patterns:
+        - 'prettier'
+        - '@vkontakte/prettier-config'
     reviewers:
       - 'VKCOM/vk-sec'
   - package-ecosystem: 'github-actions'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,18 +14,18 @@ updates:
           - 'react-dom'
           - '@types/react'
           - '@types/react-dom'
-    eslint:
-      patterns:
-        - 'eslint*'
-    jest:
-      patterns:
-        - 'jest*'
-        - '@types/jest*'
-        - 'babel-jest'
-    prettier:
-      patterns:
-        - 'prettier'
-        - '@vkontakte/prettier-config'
+      eslint:
+        patterns:
+          - 'eslint*'
+      jest:
+        patterns:
+          - 'jest*'
+          - '@types/jest*'
+          - 'babel-jest'
+      prettier:
+        patterns:
+          - 'prettier'
+          - '@vkontakte/prettier-config'
     reviewers:
       - 'VKCOM/vk-sec'
   - package-ecosystem: 'github-actions'


### PR DESCRIPTION
Перед отправкой этого реквеста на ревью убедитесь, что:

- в вашей ветке работает сборка (`npm run build:local`),
- в вашей ветке проходят тесты (`npm test`),
- в вашей ветке проходит линтер (`npm run lint`), некоторые ошибки можно автоматически поправить с помощью `npm run lint:fix`,
- покрытие тестов не ниже минимального значения,
- если вы вносите изменения в задокументированные части библиотеки,
  ваш pull request содержит обновления документации,
- если вы вносите изменения в сами токены, вы
  согласовали их с дизайнерами.

[Подробнее о внесении изменений в репозиторий токенов](https://github.com/VKCOM/vkui-tokens/blob/master/CONTRIBUTING.md)

---
Увеличила лимит PR'ов до 10, потому что [часто](https://github.com/VKCOM/vkui-tokens/network/updates/13759000/jobs) упирались в лимит
Добавила группировку, чтобы общие апдейты прилетали одним PR'ом