### PR TITLE
Extend Spacing system

### DIFF
--- a/src/build/helpers/convertCamelToSnake.test.ts
+++ b/src/build/helpers/convertCamelToSnake.test.ts
@@ -19,8 +19,15 @@ describe('convertCamelToSnake', () => {
 		expect(convertCamelToSnake('desktopS')).toBe('desktop_s');
 	});
 
+	it('should convert two words string with number prefix', () => {
+		expect(convertCamelToSnake('desktop3S')).toBe('desktop_3s');
+	});
+
 	it('should convert many words string', () => {
-		expect(convertCamelToSnake('helloWorldMyFriend')).toBe('hello_world_my_friend');
+		expect(convertCamelToSnake('hello1SWorldMy2XsFriend3Xs')).toBe(
+			'hello_1s_world_my_2xs_friend_3xs',
+		);
+		expect(convertCamelToSnake('sizeGridColumn1X2')).toBe('size_grid_column1_x2');
 	});
 
 	it('should convert special case 1', () => {

--- a/src/build/helpers/convertCamelToSnake.test.ts
+++ b/src/build/helpers/convertCamelToSnake.test.ts
@@ -30,6 +30,13 @@ describe('convertCamelToSnake', () => {
 		expect(convertCamelToSnake('sizeGridColumn1X2')).toBe('size_grid_column1_x2');
 	});
 
+	it('shows edge case with wrong convertion when size group with number in the middle of token and number stands next to it', () => {
+		// это пример когда работает не так как ожидается, но пока что в существующих токенах
+		// нету необходимости в таком преобразовании.
+		expect(convertCamelToSnake('size2Xs3Regular2L')).not.toBe('size2x_3_regular_2l');
+		expect(convertCamelToSnake('size2Xs3Regular2L')).toBe('size2_xs3_regular_2l');
+	});
+
 	it('should convert special case 1', () => {
 		expect(convertCamelToSnake('octaviusShadowLetterList')).toBe('octavius_shadow_letter_list');
 	});

--- a/src/build/helpers/convertCamelToSnake.test.ts
+++ b/src/build/helpers/convertCamelToSnake.test.ts
@@ -28,7 +28,10 @@ describe('convertCamelToSnake', () => {
 			'hello_1s_world_my_2xs_friend_3xs',
 		);
 		expect(convertCamelToSnake('sizeGridColumn1X2')).toBe('size_grid_column1_x2');
-		expect(convertCamelToSnake('size2Xs3Regular2L')).toBe('size_2xs_3regular_2l');
+		expect(convertCamelToSnake('size2XsRegular2L')).toBe('size_2xs_regular_2l');
+	});
+	it('should convert many words string', () => {
+		expect(convertCamelToSnake('fontCaption2Caps')).toBe('font_caption2_caps');
 	});
 
 	it('should convert special case 1', () => {

--- a/src/build/helpers/convertCamelToSnake.test.ts
+++ b/src/build/helpers/convertCamelToSnake.test.ts
@@ -33,6 +33,9 @@ describe('convertCamelToSnake', () => {
 	it('should convert many words string', () => {
 		expect(convertCamelToSnake('fontCaption2Caps')).toBe('font_caption2_caps');
 	});
+	it('should convert many words string', () => {
+		expect(convertCamelToSnake('searchCaption2MailSans')).toBe('search_caption2_mail_sans');
+	});
 
 	it('should convert special case 1', () => {
 		expect(convertCamelToSnake('octaviusShadowLetterList')).toBe('octavius_shadow_letter_list');

--- a/src/build/helpers/convertCamelToSnake.test.ts
+++ b/src/build/helpers/convertCamelToSnake.test.ts
@@ -28,13 +28,7 @@ describe('convertCamelToSnake', () => {
 			'hello_1s_world_my_2xs_friend_3xs',
 		);
 		expect(convertCamelToSnake('sizeGridColumn1X2')).toBe('size_grid_column1_x2');
-	});
-
-	it('shows edge case with wrong convertion when size group with number in the middle of token and number stands next to it', () => {
-		// это пример когда работает не так как ожидается, но пока что в существующих токенах
-		// нету необходимости в таком преобразовании.
-		expect(convertCamelToSnake('size2Xs3Regular2L')).not.toBe('size2x_3_regular_2l');
-		expect(convertCamelToSnake('size2Xs3Regular2L')).toBe('size2_xs3_regular_2l');
+		expect(convertCamelToSnake('size2Xs3Regular2L')).toBe('size_2xs_3regular_2l');
 	});
 
 	it('should convert special case 1', () => {

--- a/src/build/helpers/convertCamelToSnake.test.ts
+++ b/src/build/helpers/convertCamelToSnake.test.ts
@@ -29,11 +29,7 @@ describe('convertCamelToSnake', () => {
 		);
 		expect(convertCamelToSnake('sizeGridColumn1X2')).toBe('size_grid_column1_x2');
 		expect(convertCamelToSnake('size2XsRegular2L')).toBe('size_2xs_regular_2l');
-	});
-	it('should convert many words string', () => {
 		expect(convertCamelToSnake('fontCaption2Caps')).toBe('font_caption2_caps');
-	});
-	it('should convert many words string', () => {
 		expect(convertCamelToSnake('searchCaption2MailSans')).toBe('search_caption2_mail_sans');
 	});
 

--- a/src/build/helpers/convertCamelToSnake.ts
+++ b/src/build/helpers/convertCamelToSnake.ts
@@ -3,9 +3,9 @@
  */
 
 // 2Xs, 3Xs, 4S
-export const SIZE_SUB_GROUP = '[0-9][X,S,M,L][s,m,l]{0,1}(?=([A-Z]|[a-z]{3,}|[0-9][A-Z]|$))';
-// const SIZE_SUB_GROUP = '\\d[A-Z](?!([a-z]{2,}|[0-9][A-Z]{0,1}))';
+export const SIZE_SUB_GROUP = '[0-9][X,S,M,L][s,m,l]{0,1}(?=([A-Z]|[0-9][A-Z]|$))';
 const REPLACE_REGEXP = new RegExp(`(${SIZE_SUB_GROUP}|[A-Z])`, 'g');
+
 export function convertCamelToSnake(str: string): string {
 	return str.replace(REPLACE_REGEXP, (letter) => `_${letter.toLowerCase()}`).replace(/^_/, '');
 }

--- a/src/build/helpers/convertCamelToSnake.ts
+++ b/src/build/helpers/convertCamelToSnake.ts
@@ -3,7 +3,8 @@
  */
 
 // 2Xs, 3Xs, 4S
-const SIZE_SUB_GROUP = '\\d[A-Z][a-z]{0,1}(?![0-9])';
+export const SIZE_SUB_GROUP = '[0-9][X,S,M,L][s,m,l]{0,1}(?=([A-Z]|[a-z]{3,}|[0-9][A-Z]|$))';
+// const SIZE_SUB_GROUP = '\\d[A-Z](?!([a-z]{2,}|[0-9][A-Z]{0,1}))';
 const REPLACE_REGEXP = new RegExp(`(${SIZE_SUB_GROUP}|[A-Z])`, 'g');
 export function convertCamelToSnake(str: string): string {
 	return str.replace(REPLACE_REGEXP, (letter) => `_${letter.toLowerCase()}`).replace(/^_/, '');

--- a/src/build/helpers/convertCamelToSnake.ts
+++ b/src/build/helpers/convertCamelToSnake.ts
@@ -3,7 +3,7 @@
  */
 
 // 2Xs, 3Xs, 4S
-const SIZE_SUB_GROUP = '\\d[A-Z][a-z]{0,1}(?![^A-Z])';
+const SIZE_SUB_GROUP = '\\d[A-Z][a-z]{0,1}(?![0-9])';
 const REPLACE_REGEXP = new RegExp(`(${SIZE_SUB_GROUP}|[A-Z])`, 'g');
 export function convertCamelToSnake(str: string): string {
 	return str.replace(REPLACE_REGEXP, (letter) => `_${letter.toLowerCase()}`).replace(/^_/, '');

--- a/src/build/helpers/convertCamelToSnake.ts
+++ b/src/build/helpers/convertCamelToSnake.ts
@@ -1,6 +1,10 @@
 /**
  * camelCase -> snake_case
  */
+
+// 2Xs, 3Xs, 4S
+const SIZE_SUB_GROUP = '\\d[A-Z][a-z]{0,1}(?![^A-Z])';
+const REPLACE_REGEXP = new RegExp(`(${SIZE_SUB_GROUP}|[A-Z])`, 'g');
 export function convertCamelToSnake(str: string): string {
-	return str.replace(/([A-Z])/g, (letter) => `_${letter.toLowerCase()}`).replace(/^_/, '');
+	return str.replace(REPLACE_REGEXP, (letter) => `_${letter.toLowerCase()}`).replace(/^_/, '');
 }

--- a/src/build/helpers/unCamelcasify.test.ts
+++ b/src/build/helpers/unCamelcasify.test.ts
@@ -15,7 +15,12 @@ describe('unCamelcasify', () => {
 		expect(unCamelcasify('desktopS')).toBe('desktop-s');
 	});
 
+	it('should convert two words string with number prefix', () => {
+		expect(unCamelcasify('desktop3S')).toBe('desktop-3s');
+	});
+
 	it('should convert many words string', () => {
-		expect(unCamelcasify('helloWorldMyFriend')).toBe('hello-world-my-friend');
+		expect(unCamelcasify('hello1SWorldMy2XsFriend3Xs')).toBe('hello-1s-world-my-2xs-friend-3xs');
+		expect(unCamelcasify('sizeGridColumn1X2')).toBe('size-grid-column1-x2');
 	});
 });

--- a/src/build/helpers/unCamelcasify.test.ts
+++ b/src/build/helpers/unCamelcasify.test.ts
@@ -22,12 +22,6 @@ describe('unCamelcasify', () => {
 	it('should convert many words string', () => {
 		expect(unCamelcasify('hello1SWorldMy2XsFriend3Xs')).toBe('hello-1s-world-my-2xs-friend-3xs');
 		expect(unCamelcasify('sizeGridColumn1X2')).toBe('size-grid-column1-x2');
-	});
-
-	it('shows edge case with wrong convertion when size group with number in the middle of token and number stands next to it', () => {
-		// это пример когда работает не так как ожидается, но пока что в существующих токенах
-		// нету необходимости в таком преобразовании.
-		expect(unCamelcasify('size2Xs3Regular2L')).not.toBe('size2x-3-regular-2l');
-		expect(unCamelcasify('size2Xs3Regular2L')).toBe('size2-xs3-regular-2l');
+		expect(unCamelcasify('size2Xs3Regular2L')).not.toBe('size-2x-3regular-2l');
 	});
 });

--- a/src/build/helpers/unCamelcasify.test.ts
+++ b/src/build/helpers/unCamelcasify.test.ts
@@ -23,4 +23,11 @@ describe('unCamelcasify', () => {
 		expect(unCamelcasify('hello1SWorldMy2XsFriend3Xs')).toBe('hello-1s-world-my-2xs-friend-3xs');
 		expect(unCamelcasify('sizeGridColumn1X2')).toBe('size-grid-column1-x2');
 	});
+
+	it('shows edge case with wrong convertion when size group with number in the middle of token and number stands next to it', () => {
+		// это пример когда работает не так как ожидается, но пока что в существующих токенах
+		// нету необходимости в таком преобразовании.
+		expect(unCamelcasify('size2Xs3Regular2L')).not.toBe('size2x-3-regular-2l');
+		expect(unCamelcasify('size2Xs3Regular2L')).toBe('size2-xs3-regular-2l');
+	});
 });

--- a/src/build/helpers/unCamelcasify.ts
+++ b/src/build/helpers/unCamelcasify.ts
@@ -1,5 +1,9 @@
+// 2Xs, 3Xs, 4S
+const SIZE_SUB_GROUP = '\\d[A-Z][a-z]{0,1}(?![^A-Z])';
+const REPLACE_REGEXP = new RegExp(`(?:^\\w|${SIZE_SUB_GROUP}|[A-Z]|\\b\\w)`, 'g');
+
 export function unCamelcasify(str: string, delimeter = '-'): string {
-	return str.replace(/(?:^\w|[A-Z]|\b\w)/g, (letter, index) => {
+	return str.replace(REPLACE_REGEXP, (letter, index) => {
 		return `${index === 0 ? '' : delimeter}${letter.toLowerCase()}`;
 	});
 }

--- a/src/build/helpers/unCamelcasify.ts
+++ b/src/build/helpers/unCamelcasify.ts
@@ -1,9 +1,9 @@
+import { SIZE_SUB_GROUP } from './convertCamelToSnake';
 // 2Xs, 3Xs, 4S
-const SIZE_SUB_GROUP = '\\d[A-Z][a-z]{0,1}(?![0-9])';
 const REPLACE_REGEXP = new RegExp(`(?:^\\w|${SIZE_SUB_GROUP}|[A-Z]|\\b\\w)`, 'g');
 
 export function unCamelcasify(str: string, delimeter = '-'): string {
-	return str.replace(REPLACE_REGEXP, (letter, index) => {
-		return `${index === 0 ? '' : delimeter}${letter.toLowerCase()}`;
-	});
+	return str
+		.replace(REPLACE_REGEXP, (letter) => `${delimeter}${letter.toLowerCase()}`)
+		.replace(new RegExp(`^${delimeter}`), '');
 }

--- a/src/build/helpers/unCamelcasify.ts
+++ b/src/build/helpers/unCamelcasify.ts
@@ -1,5 +1,5 @@
 // 2Xs, 3Xs, 4S
-const SIZE_SUB_GROUP = '\\d[A-Z][a-z]{0,1}(?![^A-Z])';
+const SIZE_SUB_GROUP = '\\d[A-Z][a-z]{0,1}(?![0-9])';
 const REPLACE_REGEXP = new RegExp(`(?:^\\w|${SIZE_SUB_GROUP}|[A-Z]|\\b\\w)`, 'g');
 
 export function unCamelcasify(str: string, delimeter = '-'): string {

--- a/src/interfaces/general/geometry/index.ts
+++ b/src/interfaces/general/geometry/index.ts
@@ -437,6 +437,18 @@ export interface Sizes {
 
 export interface SpacingSizes {
 	/**
+	 * @desc Стандартный токен размера 3xs для отступов
+	 * @tags size
+	 */
+	spacingSize3Xs: number;
+
+	/**
+	 * @desc Стандартный токен размера 2xs для отступов
+	 * @tags size
+	 */
+	spacingSize2Xs: number;
+
+	/**
 	 * @desc Стандартный токен размера xs для отступов
 	 * @tags size
 	 */
@@ -465,4 +477,10 @@ export interface SpacingSizes {
 	 * @tags size
 	 */
 	spacingSizeXl: number;
+
+	/**
+	 * @desc Стандартный токен размера 2xl для отступов
+	 * @tags size
+	 */
+	spacingSize2Xl: number;
 }

--- a/src/themeDescriptions/base/paradigm.ts
+++ b/src/themeDescriptions/base/paradigm.ts
@@ -735,11 +735,14 @@ export const lightThemeBase: ThemeDescription = {
 	},
 
 	// Стандартные токены для отступов
-	spacingSizeXs: 4,
-	spacingSizeS: 6,
-	spacingSizeM: 8,
-	spacingSizeL: 10,
-	spacingSizeXl: 12,
+	spacingSize3Xs: 2,
+	spacingSize2Xs: 4,
+	spacingSizeXs: 6,
+	spacingSizeS: 8,
+	spacingSizeM: 12,
+	spacingSizeL: 16,
+	spacingSizeXl: 20,
+	spacingSize2Xl: 24,
 
 	// Прочие отступы
 	elevation1: '0 2px 6px 0 rgba(0, 16, 61, 0.08), 0 1px 2px 0 rgba(0, 16, 61, 0.08)',

--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -709,11 +709,14 @@ export const lightTheme: ThemeDescription = {
 	},
 
 	// Стандартные токены для отступов
-	spacingSizeXs: 4,
-	spacingSizeS: 6,
-	spacingSizeM: 8,
-	spacingSizeL: 10,
-	spacingSizeXl: 12,
+	spacingSize3Xs: 2,
+	spacingSize2Xs: 4,
+	spacingSizeXs: 6,
+	spacingSizeS: 8,
+	spacingSizeM: 12,
+	spacingSizeL: 16,
+	spacingSizeXl: 20,
+	spacingSize2Xl: 24,
 
 	// Разное
 	animationDurationL: '0.4s',


### PR DESCRIPTION
Перед отправкой этого реквеста на ревью убедитесь, что:
- [x] в вашей ветке работает сборка (`npm run build:local`),
- [x] в вашей ветке проходят тесты (`npm test`),
- [x] в вашей ветке проходит линтер (`npm run lint`), некоторые ошибки можно автоматически поправить с помощью `npm run lint:fix`,
- [x] покрытие тестов не ниже минимального значения,
- [x] если вы вносите изменения в задокументированные части библиотеки,
  ваш pull request содержит обновления документации,
- [x] если вы вносите изменения в сами токены, вы
  согласовали их с дизайнерами. (c Алексеем Зайцевым)

[Подробнее о внесении изменений в репозиторий токенов](https://github.com/VKCOM/vkui-tokens/blob/master/CONTRIBUTING.md)


## Описание
Основано на задаче из VKUI: VKCOM/VKUI#6684 и обсуждении https://github.com/VKCOM/VKUI/discussions/5928. C дизайнерами VKUI также обсудили и именно этот набор токенов решено дальше поддерживать.
- добавили новые и изменили существующие токены для системы состояний, например `spacingSizeS`.
- внёс небольшое изменение в преобразование токенов в snake_case, чтобы сохранить группы типа `2Xs` и `3Xs` и `2Xl` вместе, иначе со старой логикой получалось немного странно для таких токенов.
  Вот пример для spacingSize2Xl
  ```diff
  - --vkui--spacing_size2_xl  // старая логика
  + --vkui--spacing_size_2xl  // новая логика
  ```
Но сразу оговорюсь, что ничего не имею против оставить как есть, просто немного не интуитивно. По тестам проверил, что больше никакие токены не меняются, регулярка изменяет только такую запись.
