### PR TITLE
fix: tint colors normalization

### DIFF
--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -83,11 +83,20 @@ export const colorFromFigma = (colorsScheme: 'light' | 'dark'): ColorsDescriptio
 			}[colorsScheme],
 			colorBackgroundModal: background.background_modal,
 			colorBackgroundModalInverse: background.background_modal_inverse,
-			colorBackgroundWarning: background.background_warning,
+			colorBackgroundWarning: {
+				light: '#FFF2D6',
+				dark: '#5B4D35',
+			}[colorsScheme],
 			colorBackgroundPositive: background.background_positive,
 			colorBackgroundNegative: background.background_negative,
-			colorBackgroundNegativeTint: background.background_negative_tint,
-			colorBackgroundPositiveTint: background.background_positive_tint,
+			colorBackgroundNegativeTint: {
+				light: '#FFE9E9',
+				dark: '#522E2E',
+			}[colorsScheme],
+			colorBackgroundPositiveTint: {
+				light: '#E8F9E8',
+				dark: '#2E3E2B',
+			}[colorsScheme],
 			colorFieldBackground: background.field_background,
 			colorHeaderBackground: background.header_background,
 


### PR DESCRIPTION
Нормализовали подложечные тинт-цвета в тёмной теме и сделали чуть более насыщенный красный тинт в светлой теме.
<img width="1142" alt="image" src="https://github.com/VKCOM/vkui-tokens/assets/32414396/2f324909-7d6f-4407-9e88-3805e3b0a143">