### PR TITLE
fix: increased saturation of colorBackgroundWarning

### DIFF
--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -135,8 +135,8 @@ export const colorFromFigma = (colorsScheme: 'light' | 'dark'): ColorsDescriptio
 			colorIconContrastSecondary: icons.icon_contrast_secondary,
 			colorIconPositive: icons.icon_positive,
 			colorIconWarning: {
-				light: '#E1B406',
-				dark: '#DBAF06',
+				light: '#F8A01C',
+				dark: '#EDB055',
 			}[colorsScheme],
 			colorIconNegative: icons.icon_negative,
 

--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -85,7 +85,7 @@ export const colorFromFigma = (colorsScheme: 'light' | 'dark'): ColorsDescriptio
 			colorBackgroundModalInverse: background.background_modal_inverse,
 			colorBackgroundWarning: {
 				light: '#FFF2D6',
-				dark: '#5B4D35',
+				dark: '#473315',
 			}[colorsScheme],
 			colorBackgroundPositive: background.background_positive,
 			colorBackgroundNegative: background.background_negative,


### PR DESCRIPTION
Дизайнеры предложили сделать тёмный warning чуть чище, чем он был в жёлтом оттенке. Он стал оранжевым и более насыщенным.
![image](https://github.com/VKCOM/vkui-tokens/assets/32414396/911ba71a-80f8-4b19-924d-d4f81fc6c53d)
