### PR TITLE
fix: colorIconSecondaryAlpha in dark theme

### DIFF
--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -127,7 +127,10 @@ export const colorFromFigma = (colorsScheme: 'light' | 'dark'): ColorsDescriptio
 			colorIconMedium: icons.icon_medium,
 			colorIconMediumAlpha: icons.icon_medium_alpha,
 			colorIconSecondary: icons.icon_secondary,
-			colorIconSecondaryAlpha: icons.icon_secondary_alpha,
+			colorIconSecondaryAlpha: {
+				light: 'rgba(0, 0, 0, 0.36)',
+				dark: 'rgba(241, 247, 255, 0.43)',
+			}[colorsScheme],
 			colorIconTertiary: icons.icon_tertiary,
 			colorIconTertiaryAlpha: icons.icon_tertiary_alpha,
 			colorIconContrast: icons.icon_contrast,


### PR DESCRIPTION
Починил Icon Secondary Alpha в тёмной теме

![image](https://github.com/VKCOM/vkui-tokens/assets/32414396/0057365b-a58d-4910-993d-e6e7a75cefb5)
