### PR TITLE
4.48.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vkui-tokens",
-  "version": "4.47.0",
+  "version": "4.48.0",
   "description": "Репозиторий, который содержит в себе дизайн-токены и другие инструменты объединенной дизайн-системы VKUI и Paradigm",
   "license": "MIT",
   "homepage": "https://vkcom.github.io/vkui-tokens",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "rimraf": "5.0.7",
     "style-loader": "4.0.0",
     "terser-webpack-plugin": "5.3.10",
-    "ts-jest": "29.1.4",
+    "ts-jest": "29.1.5",
     "ts-loader": "9.5.1",
     "ts-morph": "20.0.0",
     "ts-node": "10.9.2",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "color": "4.2.3",
     "common-tags": "1.8.2",
     "copy-webpack-plugin": "12.0.2",
-    "css-loader": "7.1.1",
+    "css-loader": "7.1.2",
     "css.escape": "1.5.1",
     "eslint": "8.56.0",
     "eslint-config-prettier": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "jest-junit": "16.0.0",
     "lint-staged": "15.2.7",
     "lodash": "4.17.21",
-    "prettier": "3.2.5",
+    "prettier": "3.3.2",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "rimraf": "5.0.7",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@vkontakte/appearance": "https://github.com/VKCOM/Appearance#v10.2.0",
     "@vkontakte/icons": "2.114.0",
     "@vkontakte/prettier-config": "0.1.0",
-    "@vkontakte/vk-bridge": "2.14.1",
+    "@vkontakte/vk-bridge": "2.14.2",
     "@vkontakte/vkjs": "1.1.2",
     "@vkontakte/vkui": "6.1.1",
     "babel-jest": "29.7.0",

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "ts-node": "10.9.2",
     "tsconfig-paths": "4.2.0",
     "tscpaths": "0.0.9",
-    "type-fest": "4.18.2",
+    "type-fest": "4.20.1",
     "typescript": "5.2.2",
     "typescript-eslint": "7.0.1",
     "webpack": "5.91.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "@vkontakte/appearance": "https://github.com/VKCOM/Appearance#v10.2.0",
-    "@vkontakte/icons": "2.114.0",
+    "@vkontakte/icons": "2.123.0",
     "@vkontakte/prettier-config": "0.1.0",
     "@vkontakte/vk-bridge": "2.14.2",
     "@vkontakte/vkjs": "1.1.2",

--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -81,8 +81,14 @@ export const colorFromFigma = (colorsScheme: 'light' | 'dark'): ColorsDescriptio
 				light: '#FFFFFF',
 				dark: '#323232',
 			}[colorsScheme],
-			colorBackgroundModal: background.background_modal,
-			colorBackgroundModalInverse: background.background_modal_inverse,
+			colorBackgroundModal: {
+				light: '#FFFFFF',
+				dark: '#1C1D1E',
+			}[colorsScheme],
+			colorBackgroundModalInverse: {
+				light: '#1C1D1E',
+				dark: '#FFFFFF',
+			}[colorsScheme],
 			colorBackgroundPositive: background.background_positive,
 			colorBackgroundPositiveTint: {
 				light: '#E8F9E8',

--- a/yarn.lock
+++ b/yarn.lock
@@ -8002,10 +8002,10 @@ type-detect@4.0.8:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-type-fest@4.18.2:
-  version "4.18.2"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.18.2.tgz#8d765c42e7280a11f4d04fb77a00dacc417c8b05"
-  integrity sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==
+type-fest@4.20.1:
+  version "4.20.1"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-4.20.1.tgz#d97bb1e923bf524e5b4b43421d586760fb2ee8be"
+  integrity sha512-R6wDsVsoS9xYOpy8vgeBlqpdOyzJ12HNfQhC/aAKWM3YoCV9TtunJzh/QpkMgeDhkoynDcw5f1y+qF9yc/HHyg==
 
 type-fest@^0.20.2:
   version "0.20.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7906,10 +7906,10 @@ ts-api-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.2.1.tgz#f716c7e027494629485b21c0df6180f4d08f5e8b"
   integrity sha512-RIYA36cJn2WiH9Hy77hdF9r7oEwxAtB/TS9/S4Qd90Ap4z5FSiin5zEiTL44OII1Y3IIlEvxwxFUVgrHSZ/UpA==
 
-ts-jest@29.1.4:
-  version "29.1.4"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.4.tgz#26f8a55ce31e4d2ef7a1fd47dc7fa127e92793ef"
-  integrity sha512-YiHwDhSvCiItoAgsKtoLFCuakDzDsJ1DLDnSouTaTmdOcOwIkSzbLXduaQ6M5DRVhuZC/NYaaZ/mtHbWMv/S6Q==
+ts-jest@29.1.5:
+  version "29.1.5"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-29.1.5.tgz#d6c0471cc78bffa2cb4664a0a6741ef36cfe8f69"
+  integrity sha512-UuClSYxM7byvvYfyWdFI+/2UxMmwNyJb0NPkZPQE2hew3RurV7l7zURgOHAd/1I1ZdPpe3GUsXNXAcN8TFKSIg==
   dependencies:
     bs-logger "0.x"
     fast-json-stable-stringify "2.x"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8474,9 +8474,9 @@ write-file-atomic@^4.0.2:
     signal-exit "^3.0.7"
 
 ws@^8.16.0:
-  version "8.16.0"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.16.0.tgz#d1cd774f36fbc07165066a60e40323eab6446fd4"
-  integrity sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==
+  version "8.17.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.17.1.tgz#9293da530bb548febc95371d90f9c878727d919b"
+  integrity sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==
 
 xml@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2150,10 +2150,10 @@
   resolved "https://registry.yarnpkg.com/@vkontakte/prettier-config/-/prettier-config-0.1.0.tgz#4bb288d12a4a3f38cab1827bf7b94b10888773a9"
   integrity sha512-Ec0V5C4IUUZm/7cxHX1AowXRdK3lBEoXXCDxZ8Ii6N3MPhYOXDfegen3ld40mmtQA1jMpJdiqpH+E8e8st/zTg==
 
-"@vkontakte/vk-bridge@2.14.1":
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/@vkontakte/vk-bridge/-/vk-bridge-2.14.1.tgz#5966d9e2837570d7aed78d654bfda4ba83695c54"
-  integrity sha512-ygUkWmAj1Yca1y6OKcFRhZjM2jJ8dlD/YM0hbz86iXc3Xrd8fc1aKGAOLmgPsXkqBR3mWMxA7PoNdlVLB97Qpg==
+"@vkontakte/vk-bridge@2.14.2":
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/@vkontakte/vk-bridge/-/vk-bridge-2.14.2.tgz#7b8e8f120b9128e9c6e8424f56afbb28f6918ff2"
+  integrity sha512-npPEBw6nCLNv1vxJr7fUOsEEfglP8soOi2B2fscgE/aTxd00MF/nITzSq+LASrfSgpk/f3AtAw3CnE3Ia5E98w==
 
 "@vkontakte/vkjs@1.1.2", "@vkontakte/vkjs@^1.1.2":
   version "1.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3280,10 +3280,10 @@ cross-spawn@^7.0.0, cross-spawn@^7.0.2, cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-css-loader@7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-7.1.1.tgz#de4163c0cb765c03d7957eb9e0a49c7f354948c7"
-  integrity sha512-OxIR5P2mjO1PSXk44bWuQ8XtMK4dpEqpIyERCx3ewOo3I8EmbcxMPUc5ScLtQfgXtOojoMv57So4V/C02HQLsw==
+css-loader@7.1.2:
+  version "7.1.2"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-7.1.2.tgz#64671541c6efe06b0e22e750503106bdd86880f8"
+  integrity sha512-6WvYYn7l/XEGN8Xu2vWFt9nVzrCn39vKyTEFf/ExEyoksJjjSZV/0/35XPlMbpnr6VGhZIUg5yJrL8tGfes/FA==
   dependencies:
     icss-utils "^5.1.0"
     postcss "^8.4.33"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6762,10 +6762,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@3.2.5:
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.2.5.tgz#e52bc3090586e824964a8813b09aba6233b28368"
-  integrity sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==
+prettier@3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.2.tgz#03ff86dc7c835f2d2559ee76876a3914cec4a90a"
+  integrity sha512-rAVeHYMcv8ATV5d508CFdn+8/pHPpXeIid1DdrPwXnaAdH7cqjVbpJaT5eq4yRAFU/lsbwYwSF/n5iNrdJHPQA==
 
 pretty-error@^4.0.0:
   version "4.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1637,7 +1637,7 @@
     "@svgr/plugin-jsx" "8.1.0"
     "@svgr/plugin-svgo" "8.1.0"
 
-"@swc/helpers@^0.5.0", "@swc/helpers@^0.5.10", "@swc/helpers@^0.5.11":
+"@swc/helpers@^0.5.0", "@swc/helpers@^0.5.11":
   version "0.5.11"
   resolved "https://registry.yarnpkg.com/@swc/helpers/-/helpers-0.5.11.tgz#5bab8c660a6e23c13b2d23fcd1ee44a2db1b0cb7"
   integrity sha512-YNlnKRWF2sVojTpIyzwou9XoTNbzbzONwRhOoniEioF1AtaitTvVZblaQRrAzChWQ1bLYyYSWzM18y4WwgzJ+A==
@@ -2117,13 +2117,6 @@
   version "10.2.0"
   resolved "https://github.com/VKCOM/Appearance#3d00c758d67a4bbbd49e86f6e2eb0459f04aeefc"
 
-"@vkontakte/icons-sprite@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@vkontakte/icons-sprite/-/icons-sprite-2.1.0.tgz#841fcc19056f3f50338a43638c45afd9909befb1"
-  integrity sha512-1wN/Mrftt0hhbIwSAAODlxEoVpLN4eBs/YfY1LntrUkd9RZfxckiTy0NIk3LNmPIgV+HFYM+aAChgsE4tua6qQ==
-  dependencies:
-    "@swc/helpers" "^0.5.10"
-
 "@vkontakte/icons-sprite@2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@vkontakte/icons-sprite/-/icons-sprite-2.2.0.tgz#b736ed8581c9565ea40aaa55377cf4ec6ed2f192"
@@ -2131,17 +2124,10 @@
   dependencies:
     "@swc/helpers" "^0.5.11"
 
-"@vkontakte/icons@2.114.0":
-  version "2.114.0"
-  resolved "https://registry.yarnpkg.com/@vkontakte/icons/-/icons-2.114.0.tgz#085d29756ad052ffc3072502007e9b6042a3e803"
-  integrity sha512-NnEBQ6CAVefJSA+eGeYZ/EM2HJ0fzIbgfVSyjrRyjwnUSkLZCxy3Ouy3wiSGJBhZV9W+cxE8CHpnAsPVkjXK4w==
-  dependencies:
-    "@vkontakte/icons-sprite" "2.1.0"
-
-"@vkontakte/icons@^2.115.0":
-  version "2.121.0"
-  resolved "https://registry.yarnpkg.com/@vkontakte/icons/-/icons-2.121.0.tgz#84127dd6966daa8222b6299abf5cbb385b8d1a53"
-  integrity sha512-KEUbYAYZcXaoByhIos4CqJ8/D48Xdi8zksaMMP4F56hB1vth8FaK0Sn+NqDw5qbu8ssjPD4Eh0o28Qv3cZqWtA==
+"@vkontakte/icons@2.123.0", "@vkontakte/icons@^2.115.0":
+  version "2.123.0"
+  resolved "https://registry.yarnpkg.com/@vkontakte/icons/-/icons-2.123.0.tgz#d6a561e50784c20da160b11d140f882fed8c3a07"
+  integrity sha512-kPPnRdpmMBSQCAtZ+D5zy3I1WiDBYwl8C2jVHEmH9v4IujfrUCgIaaLc7WeKZj3vUSnWOXZ7ftCI3NU3BPWzKQ==
   dependencies:
     "@vkontakte/icons-sprite" "2.2.0"
 


### PR DESCRIPTION
**Изменённые токены**
- Изменён токен `colorBackgroundModal` в базовой теме `vk` и всех наследниках #933

**Инфраструктура**
- Изменены версии devDeps:
  - prettier from 3.2.5 to 3.3.2 #923 @dependabot
  - @vkontakte/vk-bridge from 2.14.1 to 2.14.2 #924 @dependabot
  - type-fest from 4.18.2 to 4.20.1 #925 @dependabot
  - css-loader from 7.1.1 to 7.1.2 #926 @dependabot
  - ts-jest from 29.1.4 to 29.1.5 #927 @dependabot
  - ws from 8.16.0 to 8.17.1 #929 @dependabot
  - @vkontakte/icons from 2.114.0 to 2.123.0 #934 @dependabot