### PR TITLE
fix: remove needless spread for array

### DIFF
--- a/src/build/themeProcessors/customMedia/customMedia.ts
+++ b/src/build/themeProcessors/customMedia/customMedia.ts
@@ -14,9 +14,7 @@ import {
 export const getUsingViewports = <Vt extends ViewportsTuple>(
 	breakpoints: Breakpoints<Vt>['breakpoints'],
 ): Vt => {
-	const usingViewports: Vt[number][] = [
-		...(Object.keys(breakpoints) as (keyof typeof breakpoints)[]),
-	];
+	const usingViewports: Vt[number][] = Object.keys(breakpoints) as (keyof typeof breakpoints)[];
 
 	return usingViewports.sort((a, b) =>
 		viewports.indexOf(a) > viewports.indexOf(b) ? 1 : -1,


### PR DESCRIPTION
`Object.keys` уже возвращает `array` и в данном случае лишний spread только создает лишнюю промежуточную коллекцию.