### PR TITLE
feat: Rounded values for gradient stops

### DIFF
--- a/src/build/helpers/getGradientPointsFromColor.test.ts
+++ b/src/build/helpers/getGradientPointsFromColor.test.ts
@@ -6,10 +6,10 @@ describe('getGradientPointsFromColor', () => {
 	it('should generate gradient from color', () => {
 		expect(getGradientPointsFromColor('rgb(0, 100, 200)')).toEqual(
 			'rgba(0, 100, 200, 0) 0%, ' +
-				'rgba(0, 100, 200, 0.036) 13%, ' +
-				'rgba(0, 100, 200, 0.15) 27%, ' +
-				'rgba(0, 100, 200, 0.79) 68%, ' +
-				'rgba(0, 100, 200, 0.95) 84%, ' +
+				'rgba(0, 100, 200, 0.05) 15%, ' +
+				'rgba(0, 100, 200, 0.2) 30%, ' +
+				'rgba(0, 100, 200, 0.8) 70%, ' +
+				'rgba(0, 100, 200, 0.95) 85%, ' +
 				'rgba(0, 100, 200, 1) 100%',
 		);
 	});

--- a/src/build/helpers/getGradientPointsFromColor.ts
+++ b/src/build/helpers/getGradientPointsFromColor.ts
@@ -11,10 +11,10 @@ export function getGradientPointsFromColor(
 ): GradientPoints {
 	const opacityMap: OpacityMap = [
 		[0, 0],
-		[0.036, 13],
-		[0.15, 27],
-		[0.79, 68],
-		[0.95, 84],
+		[0.05, 15],
+		[0.2, 30],
+		[0.8, 70],
+		[0.95, 85],
 		[1, 100],
 	];
 


### PR DESCRIPTION
Свели карту прозрачности градиентов к более «круглым» числам.

![image](https://github.com/user-attachments/assets/a8ad8cfc-3566-4f86-82c2-2424aa4fc952)
