### PR TITLE
fix(vkBase): Background Contrast Themed = Background Contrast Inverse

### DIFF
--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -79,7 +79,7 @@ export const colorFromFigma = (colorsScheme: 'light' | 'dark'): ColorsDescriptio
 			colorBackgroundContrastInverse: background.background_contrast_inverse,
 			colorBackgroundContrastThemed: {
 				light: '#FFFFFF',
-				dark: '#323232',
+				dark: '#2C2D2E',
 			}[colorsScheme],
 			colorBackgroundModal: {
 				light: '#FFFFFF',


### PR DESCRIPTION
Привёл Background Contrast Themed и Background Contrast Inverse к единому цвету в тёмной версии базовой темы.

![image](https://github.com/user-attachments/assets/7d45ca78-e84c-4b89-a674-7a5082f77954)