### PR TITLE
fix(VKCOM theme): Use vkCom theme color for vkCom gradient instead of base vk theme

### DIFF
--- a/src/themeDescriptions/themes/vkCom/index.ts
+++ b/src/themeDescriptions/themes/vkCom/index.ts
@@ -1,7 +1,9 @@
 import { vkcom_dark, vkcom_light } from '@vkontakte/appearance/main.valette/scheme_web.json';
 import lodash from 'lodash';
 
+import { getGradientPointsFromColor } from '@/build/helpers/getGradientPointsFromColor';
 import { ColorsDescription } from '@/interfaces/general';
+import { Gradients } from '@/interfaces/general/gradients';
 import { DeepPartial } from '@/interfaces/general/tools/utils';
 import { ThemeVkComDescription } from '@/interfaces/themes/vkCom';
 import { ThemeVkComDarkDescription } from '@/interfaces/themes/vkComDark';
@@ -394,10 +396,16 @@ const vkComDarkColor: ColorsDescription = {
 	},
 };
 
+export const vkComDarkGradient: Gradients = {
+	...darkGradient,
+	gradientTint: getGradientPointsFromColor(resolveColor(vkcom_dark.colors.background_light)),
+	gradient: getGradientPointsFromColor(resolveColor(vkcom_dark.colors.background_content)),
+};
+
 export const vkComThemeDark: ThemeVkComDarkDescription = {
 	...vkComTheme,
 	...vkComDarkColor,
-	...darkGradient,
+	...vkComDarkGradient,
 	...darkElevation,
 	themeName: 'vkComDark',
 	themeNameBase: 'vkCom',


### PR DESCRIPTION
It should be similar to the content backgroud color

Перед отправкой этого реквеста на ревью убедитесь, что:

- в вашей ветке работает сборка (`npm run build:local`),
- в вашей ветке проходят тесты (`npm test`),
- в вашей ветке проходит линтер (`npm run lint`), некоторые ошибки можно автоматически поправить с помощью `npm run lint:fix`,
- покрытие тестов не ниже минимального значения,
- если вы вносите изменения в задокументированные части библиотеки,
  ваш pull request содержит обновления документации,
- если вы вносите изменения в сами токены, вы
  согласовали их с дизайнерами.

[Подробнее о внесении изменений в репозиторий токенов](https://github.com/VKCOM/vkui-tokens/blob/master/CONTRIBUTING.md)
