### PR TITLE
fix(vkCom): Desaturated and transparent backgroundSecondaryAlpha

### DIFF
--- a/src/themeDescriptions/themes/vkCom/index.ts
+++ b/src/themeDescriptions/themes/vkCom/index.ts
@@ -32,11 +32,7 @@ const vkComColors = (theme: typeof vkcom_light) => ({
 	colorBackground: resolveColor(theme.colors.background_page),
 	colorBackgroundContent: resolveColor(theme.colors.background_content),
 	colorBackgroundSecondary: resolveColor(theme.colors.content_tint_background),
-	colorBackgroundSecondaryAlpha: {
-		normal: 'rgba(235, 242, 250, 0.99)',
-		hover: 'rgba(223, 234, 246, 0.99)',
-		active: 'rgba(213, 226, 241, 0.99)',
-	},
+	colorBackgroundSecondaryAlpha: 'rgba(39, 63, 92, 0.07)',
 	colorBackgroundTertiary: resolveColor(theme.colors.background_light),
 	colorBackgroundContrast: resolveColor(theme.colors.media_overlay_button_background),
 	// colorBackgroundContrastSecondaryAlpha: 'rgba(255, 255, 255, 0.20)',
@@ -355,11 +351,7 @@ const vkComDarkColor: ColorsDescription = {
 			active: '#CFD2D8',
 		},
 		colorBackgroundAccentThemedAlpha: 'rgba(255, 255, 255, 0.2)',
-		colorBackgroundSecondaryAlpha: {
-			normal: 'rgba(255, 255, 255, 0.10)',
-			hover: 'rgba(255, 255, 255, 0.12)',
-			active: 'rgba(255, 255, 255, 0.14)',
-		},
+		colorBackgroundSecondaryAlpha: 'rgba(255, 255, 255, 0.08)',
 		colorBackgroundContrastThemed: '#323232',
 		colorBackgroundModalInverse: '#FFFFFF',
 


### PR DESCRIPTION
Поправил токен backgroundSecondaryAlpha, который раньше был более голубым и непрозрачным.

![image](https://github.com/user-attachments/assets/5661d6c5-0921-46c7-ad0f-396c238da200)

Цвет на фоне Background / Content будет ближе к обычному Secondary цвету.

<img width="1254" alt="image" src="https://github.com/user-attachments/assets/38dc1ee4-4334-4007-97f0-a3e067fa65b4">
