### PR TITLE
feat(vkBase, Paradigm): Added colorBackgroundContentInverse

### DIFF
--- a/src/interfaces/general/colors/index.ts
+++ b/src/interfaces/general/colors/index.ts
@@ -76,6 +76,12 @@ export interface ColorsDescriptionStruct {
 	colorBackgroundContent: ColorDescription;
 
 	/**
+	 * @desc Цвет фона, противоположный фону контента.
+	 * @tags color, background
+	 */
+	colorBackgroundContentInverse: ColorDescription;
+
+	/**
 	 * @desc Второстепенный цвет фона
 	 * @tags color, background
 	 */

--- a/src/themeDescriptions/base/paradigm.ts
+++ b/src/themeDescriptions/base/paradigm.ts
@@ -31,6 +31,7 @@ export const lightColors: ColorsDescription = {
 		colorBackgroundAccentThemedAlpha: 'rgba(0, 119, 255, 0.2)',
 		colorBackgroundAccentAlternative: '#FF9E00',
 		colorBackgroundContent: '#FFFFFF',
+		colorBackgroundContentInverse: colorBackgroundContentDark,
 		colorBackgroundSecondary: '#F0F1F3',
 		colorBackgroundSecondaryAlpha: {
 			normal: 'rgba(0, 16, 61, 0.06)',
@@ -170,6 +171,7 @@ export const darkColors: ColorsDescription = {
 		colorBackgroundAccentThemedAlpha: 'rgba(255, 255, 255, 0.2)',
 		colorBackgroundAccentAlternative: '#FF9E00',
 		colorBackgroundContent: colorBackgroundContentDark,
+		colorBackgroundContentInverse: '#FFFFFF',
 		colorBackgroundSecondary: '#2A2A2B',
 		colorBackgroundSecondaryAlpha: {
 			normal: 'rgba(255, 255, 255, 0.12)',

--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -37,6 +37,10 @@ export const colorFromFigma = (colorsScheme: 'light' | 'dark'): ColorsDescriptio
 			}[colorsScheme],
 			colorBackground: background.background,
 			colorBackgroundContent: background.background_content,
+			colorBackgroundContentInverse: {
+				light: '#19191A',
+				dark: '#FFFFFF',
+			}[colorsScheme],
 			colorBackgroundSecondary: background.background_secondary,
 			colorBackgroundSecondaryAlpha: {
 				light: {


### PR DESCRIPTION
Добавил цвет, противоположный контентому. До этого похожую роль выполнял только Background / Modal Inverse, но в некоторые места он не подходил семантически.

![image](https://github.com/user-attachments/assets/cc52ecb9-45b9-447d-8a2d-fcbedfd3da4d)
