### PR TITLE
feat(vkontakteAndroid, vkontakteCom): More IM colors

### DIFF
--- a/src/interfaces/themes/vkontakteAndroid/index.ts
+++ b/src/interfaces/themes/vkontakteAndroid/index.ts
@@ -271,6 +271,20 @@ export interface LocalVkontakteAndroidColorsDescriptionStruct {
 	vkontakteColorImBubbleGiftText: ColorDescription;
 	vkontakteColorImBubbleGiftTextSecondary: ColorDescription;
 
+	vkontakteImBubbleIncomingAlternateHighlighted: ColorDescription;
+	vkontakteImBubbleIncomingExpiringHighlighted: ColorDescription;
+	vkontakteImBubbleOutgoingHighlighted: ColorDescription;
+
+	vkontakteImBubbleButtonBackground: ColorDescription;
+	vkontakteImBubbleButtonBackgroundHighlighted: ColorDescription;
+	vkontakteImBubbleMableOutgoing: ColorDescription;
+	vkontakteImBubbleMableOutgoingExpiringHighlighted: ColorDescription;
+	vkontakteImBubbleMableOutgoingHighlighted: ColorDescription;
+	vkontakteImBubbleMableWallpaperOutgoing: ColorDescription;
+	vkontakteImBubbleMableWallpaperOutgoingHighlighted: ColorDescription;
+	vkontakteImBubbleWallpaperButtonForeground: ColorDescription;
+
+	vkontakteImServiceMessageText: ColorDescription;
 	vkontakteColorImTextName: ColorDescription;
 
 	vkontakteButtonMutedBackground: ColorDescription;
@@ -278,10 +292,6 @@ export interface LocalVkontakteAndroidColorsDescriptionStruct {
 	vkontakteButtonTertiaryForeground: ColorDescription;
 	vkontakteFloatButtonForeground: ColorDescription;
 	vkontakteLandingBackground: ColorDescription;
-
-	vkontakteImBubbleIncomingAlternateHighlighted: ColorDescription;
-	vkontakteImBubbleIncomingExpiringHighlighted: ColorDescription;
-	vkontakteImBubbleOutgoingHighlighted: ColorDescription;
 
 	vkontakteLandingSecondaryButtonBackground: ColorDescription;
 	vkontakteStoriesSkeletonLoaderBackground: ColorDescription;

--- a/src/themeDescriptions/themes/vkontakteAndroid/index.ts
+++ b/src/themeDescriptions/themes/vkontakteAndroid/index.ts
@@ -114,6 +114,17 @@ export const vkontakteLocalColorLight: LocalVkontakteAndroidColorsDescriptionStr
 	vkontakteImBubbleIncomingExpiringHighlighted: '#ccd3ff',
 	vkontakteImBubbleOutgoingHighlighted: '#add3ff',
 
+	vkontakteImBubbleButtonBackground: '#F9F9F9',
+	vkontakteImBubbleButtonBackgroundHighlighted: '#D7D8D9',
+	vkontakteImBubbleMableOutgoing: '#D9F4FF',
+	vkontakteImBubbleMableOutgoingExpiringHighlighted: '#C2CBFF',
+	vkontakteImBubbleMableOutgoingHighlighted: '#B0E8FF',
+	vkontakteImBubbleMableWallpaperOutgoing: '#D9F4FF',
+	vkontakteImBubbleMableWallpaperOutgoingHighlighted: '#B0E8FF',
+	vkontakteImBubbleWallpaperButtonForeground: '#000000',
+
+	vkontakteImServiceMessageText: '#818C99',
+
 	vkontakteLandingSecondaryButtonBackground: 'rgba(0, 57, 115, 0.10)',
 	vkontakteStoriesSkeletonLoaderBackground: '#454647',
 
@@ -219,6 +230,17 @@ export const vkontakteLocalColorDark: LocalVkontakteAndroidColorsDescriptionStru
 	vkontakteImBubbleIncomingAlternateHighlighted: '#5d5f61',
 	vkontakteImBubbleIncomingExpiringHighlighted: '#404980',
 	vkontakteImBubbleOutgoingHighlighted: '#5d5f61',
+
+	vkontakteImBubbleButtonBackground: '#FFFFFF29',
+	vkontakteImBubbleButtonBackgroundHighlighted: '#FFFFFF3D',
+	vkontakteImBubbleMableOutgoing: '#346CAD',
+	vkontakteImBubbleMableOutgoingExpiringHighlighted: '#5965B3',
+	vkontakteImBubbleMableOutgoingHighlighted: '#4772A6',
+	vkontakteImBubbleMableWallpaperOutgoing: '#346CAD',
+	vkontakteImBubbleMableWallpaperOutgoingHighlighted: '#4772A6',
+	vkontakteImBubbleWallpaperButtonForeground: '#E1E3E6',
+
+	vkontakteImServiceMessageText: '#76787A',
 
 	vkontakteLandingSecondaryButtonBackground: 'rgba(255, 255, 255, 0.15)',
 	vkontakteStoriesSkeletonLoaderBackground: '#c4c8cc',

--- a/src/themeDescriptions/themes/vkontakteCom/index.ts
+++ b/src/themeDescriptions/themes/vkontakteCom/index.ts
@@ -109,6 +109,17 @@ const vkontakteComLocalColorLight: LocalVkontakteAndroidColorsDescriptionStruct 
 	vkontakteImBubbleIncomingExpiringHighlighted: '#ccd3ff',
 	vkontakteImBubbleOutgoingHighlighted: '#add3ff',
 
+	vkontakteImBubbleButtonBackground: '#F9F9F9',
+	vkontakteImBubbleButtonBackgroundHighlighted: '#D7D8D9',
+	vkontakteImBubbleMableOutgoing: '#D9F4FF',
+	vkontakteImBubbleMableOutgoingExpiringHighlighted: '#C2CBFF',
+	vkontakteImBubbleMableOutgoingHighlighted: '#B0E8FF',
+	vkontakteImBubbleMableWallpaperOutgoing: '#D9F4FF',
+	vkontakteImBubbleMableWallpaperOutgoingHighlighted: '#B0E8FF',
+	vkontakteImBubbleWallpaperButtonForeground: '#000000',
+
+	vkontakteImServiceMessageText: '#818C99',
+
 	vkontakteLandingSecondaryButtonBackground: 'rgba(0, 57, 115, 0.102)',
 	vkontakteStoriesSkeletonLoaderBackground: '#cccccc',
 
@@ -212,6 +223,17 @@ const vkontakteComLocalColorDark: LocalVkontakteAndroidColorsDescriptionStruct =
 	vkontakteImBubbleIncomingAlternateHighlighted: '#656565',
 	vkontakteImBubbleIncomingExpiringHighlighted: '#404980',
 	vkontakteImBubbleOutgoingHighlighted: '#656565',
+
+	vkontakteImBubbleButtonBackground: '#FFFFFF29',
+	vkontakteImBubbleButtonBackgroundHighlighted: '#FFFFFF3D',
+	vkontakteImBubbleMableOutgoing: '#346CAD',
+	vkontakteImBubbleMableOutgoingExpiringHighlighted: '#5965B3',
+	vkontakteImBubbleMableOutgoingHighlighted: '#4772A6',
+	vkontakteImBubbleMableWallpaperOutgoing: '#346CAD',
+	vkontakteImBubbleMableWallpaperOutgoingHighlighted: '#4772A6',
+	vkontakteImBubbleWallpaperButtonForeground: '#E1E3E6',
+
+	vkontakteImServiceMessageText: '#76787A',
 
 	vkontakteLandingSecondaryButtonBackground: 'rgba(255, 255, 255, 0.16)',
 	vkontakteStoriesSkeletonLoaderBackground: '#555555',


### PR DESCRIPTION
Добавлено **9 цветов** из мессенджера, которые раньше были Appearance схеме, но не переехали в VKUI Tokens. Изменение повиляло на темы vkontakteAndroid, vkontakteCom и наследуемые от них.

С кайфом отказался бы от этих токенов, но у них есть актуальные использования, и на них может быть завязана локальная мессенджерская темизация.

Названия | Использования | Светлая| Тёмная
-- | -- | -- | --
im_service_message_text | 26 | #818C99 | #76787A
im_bubble_button_background | 12 | #F9F9F9 | #FFFFFF 16%
im_bubble_button_background_highlighted | 2 | #D7D8D9 | #FFFFFF 24%
im_bubble_mable_outgoing |  2 | #D9F4FF | #346CAD
im_bubble_mable_outgoing_expiring_highlighted | 2 | #C2CBFF | #5965B3
im_bubble_mable_outgoing_highlighted | 2 | #B0E8FF | #4772A6
im_bubble_mable_wallpaper_outgoing |  2 | #D9F4FF | #346CAD
im_bubble_mable_wallpaper_outgoing_highlighted |  2 | #B0E8FF | #4772A6
im_bubble_wallpaper_button_foreground |   1 | #000000 | #E1E3E6

