### PR TITLE
fix(vkontakteCom, vkontakteAndroid): Included colorStrokePrimary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vkui-tokens",
-  "version": "4.58.0",
+  "version": "4.58.1",
   "description": "Репозиторий, который содержит в себе дизайн-токены и другие инструменты объединенной дизайн-системы VKUI и Paradigm",
   "license": "MIT",
   "homepage": "https://vkcom.github.io/vkui-tokens",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vkontakte/vkui-tokens",
-  "version": "4.57.0",
+  "version": "4.58.0",
   "description": "Репозиторий, который содержит в себе дизайн-токены и другие инструменты объединенной дизайн-системы VKUI и Paradigm",
   "license": "MIT",
   "homepage": "https://vkcom.github.io/vkui-tokens",

--- a/src/interfaces/themes/legoAndroid/index.ts
+++ b/src/interfaces/themes/legoAndroid/index.ts
@@ -1,30 +1,6 @@
-import { ThemeCssVars } from '@/interfaces/general';
-import {
-	ColorDescription,
-	ColorsDescriptionStruct,
-	ColorWithStates,
-} from '@/interfaces/general/colors';
-import {
-	LocalVkontakteAndroidColorsDescriptionStruct,
-	ThemeVkontakteAndroid,
-	ThemeVkontakteAndroidDescription,
+// Сюда нельзя добавлять локальные переменные — так условились с разработкой Android
+export {
+	ThemeVkontakteAndroid as ThemeLegoAndroid,
+	ThemeVkontakteAndroidCssVars as ThemeLegoAndroidCssVars,
+	ThemeVkontakteAndroidDescription as ThemeLegoAndroidDescription,
 } from '@/interfaces/themes/vkontakteAndroid';
-
-// Описание локальных цветов
-export interface LocalLegoAndroidColorsDescriptionStruct {
-	colorStrokePrimary: ColorDescription;
-}
-
-// Резолв локальных цветов
-export type LegoAndroidLocalColors = {
-	[key in keyof LocalLegoAndroidColorsDescriptionStruct]: ColorWithStates;
-};
-
-// Эскпорт интерфейсов описанной + наследованной темы
-export interface ThemeLegoAndroid extends ThemeVkontakteAndroid, LegoAndroidLocalColors {}
-export interface ThemeLegoAndroidDescription extends ThemeVkontakteAndroidDescription {
-	colors: LocalLegoAndroidColorsDescriptionStruct &
-		LocalVkontakteAndroidColorsDescriptionStruct &
-		ColorsDescriptionStruct;
-}
-export interface ThemeLegoAndroidCssVars extends ThemeCssVars<ThemeLegoAndroid> {}

--- a/src/interfaces/themes/vkontakteAndroid/index.ts
+++ b/src/interfaces/themes/vkontakteAndroid/index.ts
@@ -271,6 +271,20 @@ export interface LocalVkontakteAndroidColorsDescriptionStruct {
 	vkontakteColorImBubbleGiftText: ColorDescription;
 	vkontakteColorImBubbleGiftTextSecondary: ColorDescription;
 
+	vkontakteImBubbleIncomingAlternateHighlighted: ColorDescription;
+	vkontakteImBubbleIncomingExpiringHighlighted: ColorDescription;
+	vkontakteImBubbleOutgoingHighlighted: ColorDescription;
+
+	vkontakteImBubbleButtonBackground: ColorDescription;
+	vkontakteImBubbleButtonBackgroundHighlighted: ColorDescription;
+	vkontakteImBubbleMableOutgoing: ColorDescription;
+	vkontakteImBubbleMableOutgoingExpiringHighlighted: ColorDescription;
+	vkontakteImBubbleMableOutgoingHighlighted: ColorDescription;
+	vkontakteImBubbleMableWallpaperOutgoing: ColorDescription;
+	vkontakteImBubbleMableWallpaperOutgoingHighlighted: ColorDescription;
+	vkontakteImBubbleWallpaperButtonForeground: ColorDescription;
+
+	vkontakteImServiceMessageText: ColorDescription;
 	vkontakteColorImTextName: ColorDescription;
 
 	vkontakteButtonMutedBackground: ColorDescription;
@@ -278,10 +292,6 @@ export interface LocalVkontakteAndroidColorsDescriptionStruct {
 	vkontakteButtonTertiaryForeground: ColorDescription;
 	vkontakteFloatButtonForeground: ColorDescription;
 	vkontakteLandingBackground: ColorDescription;
-
-	vkontakteImBubbleIncomingAlternateHighlighted: ColorDescription;
-	vkontakteImBubbleIncomingExpiringHighlighted: ColorDescription;
-	vkontakteImBubbleOutgoingHighlighted: ColorDescription;
 
 	vkontakteLandingSecondaryButtonBackground: ColorDescription;
 	vkontakteStoriesSkeletonLoaderBackground: ColorDescription;

--- a/src/interfaces/themes/vkontakteAndroid/index.ts
+++ b/src/interfaces/themes/vkontakteAndroid/index.ts
@@ -297,6 +297,8 @@ export interface LocalVkontakteAndroidColorsDescriptionStruct {
 	vkontakteStoriesSkeletonLoaderBackground: ColorDescription;
 
 	vkontaktePaletteBlack: ColorDescription;
+
+	colorStrokePrimary: ColorDescription;
 }
 
 export type VkontakteAndroidLocalColors = {

--- a/src/themeDescriptions/themes/lego/android.ts
+++ b/src/themeDescriptions/themes/lego/android.ts
@@ -23,7 +23,7 @@ export const legoAndroidTheme: ThemeLegoAndroidDescription = {
 		// Здесь нужно прописать другие цвета с особыми различиями нейминга
 		// А также локальные цвета, используемые только в этой теме
 		// Или цвета, которые не выгружаются из фигмы, но переопределяются в этой теме
-		colorStrokePrimary: figma.appearance.strokePrimary.light,
+		// ...
 	},
 	// Изменённые не-цвета
 	sizeBasePaddingHorizontal: {
@@ -47,12 +47,7 @@ export const legoAndroidThemeDark: ThemeLegoAndroidDarkDescription = {
 
 	colors: {
 		...vkontakteAndroidThemeDark.colors,
-		// Переопределение токенов, которые есть в figma.json
 		// То же самое, что в светлой теме, но ссылаемся на figmaToken.dark вместо light
 		...overwriteFromFigmaJSON(vkontakteAndroidTheme.colors, 'appearance', 'dark', figma),
-		// Здесь нужно прописать другие цвета с особыми различиями нейминга
-		// А также локальные цвета, используемые только в этой теме
-		// Или цвета, которые не выгружаются из фигмы, но переопределяются в этой теме
-		colorStrokePrimary: figma.appearance.strokePrimary.dark,
 	},
 };

--- a/src/themeDescriptions/themes/vkontakteAndroid/index.ts
+++ b/src/themeDescriptions/themes/vkontakteAndroid/index.ts
@@ -129,6 +129,8 @@ export const vkontakteLocalColorLight: LocalVkontakteAndroidColorsDescriptionStr
 	vkontakteStoriesSkeletonLoaderBackground: '#454647',
 
 	vkontaktePaletteBlack: '#000000',
+
+	colorStrokePrimary: '#2C2D2E',
 };
 
 export const vkontakteLocalColorDark: LocalVkontakteAndroidColorsDescriptionStruct = {
@@ -246,6 +248,8 @@ export const vkontakteLocalColorDark: LocalVkontakteAndroidColorsDescriptionStru
 	vkontakteStoriesSkeletonLoaderBackground: '#c4c8cc',
 
 	vkontaktePaletteBlack: '#000000',
+
+	colorStrokePrimary: '#E1E3E6',
 };
 
 const fontFamilyAccent =

--- a/src/themeDescriptions/themes/vkontakteAndroid/index.ts
+++ b/src/themeDescriptions/themes/vkontakteAndroid/index.ts
@@ -114,6 +114,17 @@ export const vkontakteLocalColorLight: LocalVkontakteAndroidColorsDescriptionStr
 	vkontakteImBubbleIncomingExpiringHighlighted: '#ccd3ff',
 	vkontakteImBubbleOutgoingHighlighted: '#add3ff',
 
+	vkontakteImBubbleButtonBackground: '#F9F9F9',
+	vkontakteImBubbleButtonBackgroundHighlighted: '#D7D8D9',
+	vkontakteImBubbleMableOutgoing: '#D9F4FF',
+	vkontakteImBubbleMableOutgoingExpiringHighlighted: '#C2CBFF',
+	vkontakteImBubbleMableOutgoingHighlighted: '#B0E8FF',
+	vkontakteImBubbleMableWallpaperOutgoing: '#D9F4FF',
+	vkontakteImBubbleMableWallpaperOutgoingHighlighted: '#B0E8FF',
+	vkontakteImBubbleWallpaperButtonForeground: '#000000',
+
+	vkontakteImServiceMessageText: '#818C99',
+
 	vkontakteLandingSecondaryButtonBackground: 'rgba(0, 57, 115, 0.10)',
 	vkontakteStoriesSkeletonLoaderBackground: '#454647',
 
@@ -219,6 +230,17 @@ export const vkontakteLocalColorDark: LocalVkontakteAndroidColorsDescriptionStru
 	vkontakteImBubbleIncomingAlternateHighlighted: '#5d5f61',
 	vkontakteImBubbleIncomingExpiringHighlighted: '#404980',
 	vkontakteImBubbleOutgoingHighlighted: '#5d5f61',
+
+	vkontakteImBubbleButtonBackground: '#FFFFFF29',
+	vkontakteImBubbleButtonBackgroundHighlighted: '#FFFFFF3D',
+	vkontakteImBubbleMableOutgoing: '#346CAD',
+	vkontakteImBubbleMableOutgoingExpiringHighlighted: '#5965B3',
+	vkontakteImBubbleMableOutgoingHighlighted: '#4772A6',
+	vkontakteImBubbleMableWallpaperOutgoing: '#346CAD',
+	vkontakteImBubbleMableWallpaperOutgoingHighlighted: '#4772A6',
+	vkontakteImBubbleWallpaperButtonForeground: '#E1E3E6',
+
+	vkontakteImServiceMessageText: '#76787A',
 
 	vkontakteLandingSecondaryButtonBackground: 'rgba(255, 255, 255, 0.15)',
 	vkontakteStoriesSkeletonLoaderBackground: '#c4c8cc',

--- a/src/themeDescriptions/themes/vkontakteCom/index.ts
+++ b/src/themeDescriptions/themes/vkontakteCom/index.ts
@@ -109,6 +109,17 @@ const vkontakteComLocalColorLight: LocalVkontakteAndroidColorsDescriptionStruct 
 	vkontakteImBubbleIncomingExpiringHighlighted: '#ccd3ff',
 	vkontakteImBubbleOutgoingHighlighted: '#add3ff',
 
+	vkontakteImBubbleButtonBackground: '#F9F9F9',
+	vkontakteImBubbleButtonBackgroundHighlighted: '#D7D8D9',
+	vkontakteImBubbleMableOutgoing: '#D9F4FF',
+	vkontakteImBubbleMableOutgoingExpiringHighlighted: '#C2CBFF',
+	vkontakteImBubbleMableOutgoingHighlighted: '#B0E8FF',
+	vkontakteImBubbleMableWallpaperOutgoing: '#D9F4FF',
+	vkontakteImBubbleMableWallpaperOutgoingHighlighted: '#B0E8FF',
+	vkontakteImBubbleWallpaperButtonForeground: '#000000',
+
+	vkontakteImServiceMessageText: '#818C99',
+
 	vkontakteLandingSecondaryButtonBackground: 'rgba(0, 57, 115, 0.102)',
 	vkontakteStoriesSkeletonLoaderBackground: '#cccccc',
 
@@ -212,6 +223,17 @@ const vkontakteComLocalColorDark: LocalVkontakteAndroidColorsDescriptionStruct =
 	vkontakteImBubbleIncomingAlternateHighlighted: '#656565',
 	vkontakteImBubbleIncomingExpiringHighlighted: '#404980',
 	vkontakteImBubbleOutgoingHighlighted: '#656565',
+
+	vkontakteImBubbleButtonBackground: '#FFFFFF29',
+	vkontakteImBubbleButtonBackgroundHighlighted: '#FFFFFF3D',
+	vkontakteImBubbleMableOutgoing: '#346CAD',
+	vkontakteImBubbleMableOutgoingExpiringHighlighted: '#5965B3',
+	vkontakteImBubbleMableOutgoingHighlighted: '#4772A6',
+	vkontakteImBubbleMableWallpaperOutgoing: '#346CAD',
+	vkontakteImBubbleMableWallpaperOutgoingHighlighted: '#4772A6',
+	vkontakteImBubbleWallpaperButtonForeground: '#E1E3E6',
+
+	vkontakteImServiceMessageText: '#76787A',
 
 	vkontakteLandingSecondaryButtonBackground: 'rgba(255, 255, 255, 0.16)',
 	vkontakteStoriesSkeletonLoaderBackground: '#555555',

--- a/src/themeDescriptions/themes/vkontakteCom/index.ts
+++ b/src/themeDescriptions/themes/vkontakteCom/index.ts
@@ -124,6 +124,8 @@ const vkontakteComLocalColorLight: LocalVkontakteAndroidColorsDescriptionStruct 
 	vkontakteStoriesSkeletonLoaderBackground: '#cccccc',
 
 	vkontaktePaletteBlack: '#000000',
+
+	colorStrokePrimary: '#2C2D2E',
 };
 
 const vkontakteComLocalColorDark: LocalVkontakteAndroidColorsDescriptionStruct = {
@@ -239,6 +241,8 @@ const vkontakteComLocalColorDark: LocalVkontakteAndroidColorsDescriptionStruct =
 	vkontakteStoriesSkeletonLoaderBackground: '#555555',
 
 	vkontaktePaletteBlack: '#000000',
+
+	colorStrokePrimary: '#E1E3E6',
 };
 
 const vkontakteComFonts = lodash.merge<typeof vkComFonts, DeepPartial<typeof vkComFonts>>(


### PR DESCRIPTION
Внёс colorStrokePrimary в интерфейс vkontakteAndroid, потому что договорились, что все темы для андроида будут с единым набором токенов.