### PR TITLE
fix(vkBase): Updated colorBackgroundSecondaryAlpha states for dark mode

### DIFF
--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -53,11 +53,7 @@ export const colorFromFigma = (colorsScheme: 'light' | 'dark'): ColorsDescriptio
 					hover: states.background_secondary_alpha.hover,
 					active: states.background_secondary_alpha.active,
 				},
-				dark: {
-					normal: 'rgba(255, 255, 255, 0.10)',
-					hover: 'rgba(255, 255, 255, 0.12)',
-					active: 'rgba(255, 255, 255, 0.14)',
-				},
+				dark: 'rgba(255, 255, 255, 0.10)',
 			}[colorsScheme],
 			colorBackgroundTertiary: background.background_tertiary,
 			colorBackgroundTertiaryAlpha: {


### PR DESCRIPTION
Изменены значения цветов для hover- и active-состояний `colorBackgroundSecondaryAlpha`. Были указаны вручную (`rgba(255, 255, 255, 0.12)` и `rgba(255, 255, 255, 0.14)`), теперь дефолтно генерируются (`rgba(255, 255, 255, 0.14)` и `rgba(255, 255, 255, 0.18)`)

Не содержит подъём версии

![image](https://github.com/user-attachments/assets/096b07f6-dee0-403c-92e1-cebc0c09613e)
