### PR TITLE
fix(vkBase): Updated Title2 weight accordingly to design

### DIFF
--- a/src/themeDescriptions/base/vk.ts
+++ b/src/themeDescriptions/base/vk.ts
@@ -387,7 +387,7 @@ export const fonts: BaseFonts = {
 			fontSize: 20,
 			lineHeight: 24,
 			fontFamily: fontFamilyBase,
-			fontWeight: fontWeightBase1,
+			fontWeight: fontWeightBase2,
 		},
 	},
 	fontTitle3: {


### PR DESCRIPTION
Обновил дефолтную жирность стиля Title 2 в соответствии с дизайном

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/2770b1d6-a35b-4410-8eac-427ddf2207ec" />