### PR TITLE
fix: release permissions

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -10,6 +10,8 @@ jobs:
   publish:
     name: Publish
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - name: Node setup


### PR DESCRIPTION
Добавляем `permissions` для того, чтобы можно было [добавлять](https://github.com/VKCOM/vkui-tokens/actions/runs/16830208330/job/47675825708#step:7:12) билд в релиз ноутсы без ошибок

Перед отправкой этого реквеста на ревью убедитесь, что:

- в вашей ветке работает сборка (`npm run build:local`),
- в вашей ветке проходят тесты (`npm test`),
- в вашей ветке проходит линтер (`npm run lint`), некоторые ошибки можно автоматически поправить с помощью `npm run lint:fix`,
- покрытие тестов не ниже минимального значения,
- если вы вносите изменения в задокументированные части библиотеки,
  ваш pull request содержит обновления документации,
- если вы вносите изменения в сами токены, вы
  согласовали их с дизайнерами.

[Подробнее о внесении изменений в репозиторий токенов](https://github.com/VKCOM/vkui-tokens/blob/master/CONTRIBUTING.md)
