### PR TITLE
ci(publish.yml): use DEVTOOLS_GITHUB_TOKEN for checkout

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -62,6 +62,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          token: ${{ secrets.DEVTOOLS_GITHUB_TOKEN }}
 
       - name: Node setup
         uses: ./.github/actions/node-setup


### PR DESCRIPTION
- relates to #1343, #1333

`publish.yml` падает с ошибкой "You're not authorized to push to this branch." при попытке запушить в защищенную ветку.

Пробуем использовать токен при чекауте на репозиторий по примеру реп VKCOM/VKUI, VKCOM/icons и т.п.