### PR TITLE
Add Counter Color Tokens | Paradigm

### DIFF
--- a/src/themeDescriptions/base/paradigm.ts
+++ b/src/themeDescriptions/base/paradigm.ts
@@ -313,7 +313,6 @@ export const darkColors: ColorsDescription = {
 		colorCounterBackgroundSecondaryAlpha: 'rgba(255, 255, 255, 0.14)',
 		colorCounterBackgroundTertiaryAlpha: 'rgba(0, 119, 255, 0.28)',
 		colorCounterTextTertiary: '#8EC3FF',
-		
 	},
 };
 

--- a/src/themeDescriptions/base/paradigm.ts
+++ b/src/themeDescriptions/base/paradigm.ts
@@ -161,6 +161,11 @@ export const lightColors: ColorsDescription = {
 		colorButtonIcon: '#0077ff',
 		colorButtonStroke: '#0077ff',
 		colorTransparent: 'transparent',
+
+		// Counter
+		colorCounterBackgroundSecondaryAlpha: 'rgba(0, 16, 61, 0.1)',
+		colorCounterBackgroundTertiaryAlpha: 'rgba(90, 158, 255, 0.2)',
+		colorCounterTextTertiary: '#0070F0',
 	},
 };
 
@@ -303,6 +308,12 @@ export const darkColors: ColorsDescription = {
 		colorButtonIcon: '#FFFFFF',
 		colorButtonStroke: '#FFFFFF',
 		colorTransparent: 'transparent',
+
+		// Counter
+		colorCounterBackgroundSecondaryAlpha: 'rgba(255, 255, 255, 0.14)',
+		colorCounterBackgroundTertiaryAlpha: 'rgba(0, 119, 255, 0.28)',
+		colorCounterTextTertiary: '#8EC3FF',
+		
 	},
 };
 


### PR DESCRIPTION
Добавлены новые цветовые токены Counter для темы Paradigm:

- colorCounterBackgroundSecondaryAlpha
- colorCounterBackgroundTertiaryAlpha
- colorCounterTextTertiary

Добавлены значения для light и dark themes.

Проверки:
- [x] yarn test — 498/498 passed
- [x] yarn lint
- [x] snapshots updated/checked
- [x] yarn build:local
- [x] токены согласованы с дизайном